### PR TITLE
[feat] 공통 에러 핸들러 구현 / 실무테스트 문제 목록 페이지 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "router": "^2.2.0",
     "vue": "^3.5.13",
     "vue-router": "^4.5.1",
+    "vue-toastification": "^2.0.0-rc.5",
     "vuetify": "^3.8.3"
   },
   "devDependencies": {

--- a/src/apis/routes/index.js
+++ b/src/apis/routes/index.js
@@ -1,9 +1,11 @@
 import { CounterAPI } from './counter';
 import { CalculatorAPI } from './calculator';
 import { AuthAPI } from './auth';
+import { JobtestAPI } from './jobtest';
 
 export const API = {
     COUNTER: CounterAPI,
     CALCULATOR: CalculatorAPI,
     AUTH: AuthAPI,
+    JOBTEST: JobtestAPI,
 };

--- a/src/apis/routes/jobtest.js
+++ b/src/apis/routes/jobtest.js
@@ -1,0 +1,47 @@
+export const JobtestAPI = {
+    // 문제
+    QUESTIONS: '/api/v1/employment/questions',
+    QUESTION_DETAIL: (id) => `/api/v1/employment/questions/${id}`,
+
+    // 문제 선택지
+    QUESTION_OPTIONS: '/api/v1/employment/question-options',
+    QUESTION_OPTION_DETAIL: (id) => `/api/v1/employment/question-options/${id}`,
+
+    // 실무테스트
+    JOBTESTS: '/api/v1/employment/jobtests',
+    JOBTEST_DETAIL: (id) => `/api/v1/employment/jobtests/${id}`,
+
+    // 실무테스트별 문제
+    JOBTEST_QUESTIONS: '/api/v1/employment/jobtest-questions',
+    JOBTEST_QUESTION_DETAIL: (id) => `/api/v1/employment/jobtest-questions/${id}`,
+
+    // 채점 기준
+    GRADING_CRITERIA: '/api/v1/employment/grading-criteria',
+    GRADING_CRITERIA_DETAIL: (id) => `/api/v1/employment/grading-criteria/${id}`,
+
+    // 채점 결과
+    GRADING_RESULTS: '/api/v1/employment/grading-results',
+    GRADING_RESULT_DETAIL: (id) => `/api/v1/employment/grading-results/${id}`,
+
+    // 평가 기준
+    EVALUATION_CRITERIA: '/api/v1/employment/evaluation-criteria',
+    EVALUATION_CRITERIA_DETAIL: (id) => `/api/v1/employment/evaluation-criteria/${id}`,
+    EVALUATION_CRITERIA_BY_JOBTEST: (jobtestId) =>
+        `/api/v1/employment/jobtests/${jobtestId}/evaluation-criteria`,
+
+    // 평가 결과
+    EVALUATION_RESULTS: '/api/v1/employment/evaluation-results',
+    EVALUATION_RESULT_DETAIL: (id) => `/api/v1/employment/evaluation-results/${id}`,
+    EVALUATION_RESULTS_BY_APPLICATION: (applicationId) =>
+        `/api/v1/employment/applications/${applicationId}/evaluation-results`,
+
+    // 지원서별 실무테스트
+    APPLICATION_JOBTESTS: '/api/v1/employment/application-jobtests',
+    APPLICATION_JOBTEST_DETAIL: (id) => `/api/v1/employment/application-jobtests/${id}`,
+
+    // 답변
+    ANSWERS: '/api/v1/employment/answers',
+    ANSWER_DETAIL: (id) => `/api/v1/employment/answers/${id}`,
+    GRADE_ANSWER: (applicationJobtestId) =>
+        `/api/v1/employment/answers/${applicationJobtestId}/grade`,
+};

--- a/src/components/employment/JobtestListView.vue
+++ b/src/components/employment/JobtestListView.vue
@@ -1,0 +1,118 @@
+<template>
+    <v-table>
+        <thead>
+            <tr>
+                <th v-if="showCheckbox" style="width: 48px;"></th>
+                <th v-for="header in headers" :key="header.key">{{ header.label }}</th>
+                <th v-if="showArrow"></th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr v-for="(item, idx) in items" :key="idx">
+                <td v-if="showCheckbox">
+                    <v-checkbox v-model="item.selected" :ripple="false" hide-details density="compact" />
+                </td>
+                <td v-for="header in headers" :key="header.key">
+                    <slot :name="`cell-${header.key}`" :item="item" :value="item[header.key]" :header="header">
+                        <!-- 기본 분기 렌더링 -->
+                        <template v-if="header.type === 'avatar' && item[header.key]">
+                            <div class="d-flex align-center">
+                                <v-avatar class="me-2" size="28">
+                                    <v-img :src="item[header.key].avatar" />
+                                </v-avatar>
+                                <span>{{ item[header.key].name }}</span>
+                            </div>
+                        </template>
+                        <template v-else-if="header.type === 'chip'">
+                            <v-chip :color="chipColor(item[header.key])" size="small">{{ item[header.key] }}</v-chip>
+                        </template>
+                        <template v-else>
+                            {{ item[header.key] }}
+                        </template>
+                    </slot>
+                </td>
+                <td v-if="showArrow">
+                    <v-icon>mdi-arrow-right</v-icon>
+                </td>
+            </tr>
+        </tbody>
+    </v-table>
+</template>
+
+<script setup>
+const props = defineProps({
+    headers: { type: Array, required: true },
+    items: { type: Array, required: true },
+    showCheckbox: { type: Boolean, default: false },
+    showArrow: { type: Boolean, default: true }
+})
+
+function chipColor(val) {
+    if (val === '쉬움' || val === '대기') return 'green lighten-4'
+    if (val === '보통' || val === '처리중') return 'blue lighten-4'
+    if (val === '어려움' || val === '완료') return 'red lighten-4'
+    return 'grey lighten-4'
+}
+</script>
+
+<style scoped>
+th {
+    font-weight: bold;
+    color: #9A9A9A;
+    text-align: left;
+    padding: 12px 16px;
+    font-size: 14px;
+}
+
+td {
+    vertical-align: middle;
+    padding: 16px;
+    font-size: 14px;
+    color: #333333;
+    border-bottom: 1px solid #EEEEEE;
+}
+
+.v-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+tr:hover {
+    background-color: #F9F9F9;
+}
+
+.v-avatar {
+    margin-right: 12px;
+}
+
+.v-chip {
+    font-size: 12px;
+    font-weight: 500;
+}
+
+thead th {
+    background-color: #F8F8F8;
+    position: sticky;
+    top: 0;
+    z-index: 1;
+}
+
+.v-icon {
+    cursor: pointer;
+    color: #9A9A9A;
+}
+
+tbody tr td:last-child {
+    text-align: right;
+    padding-right: 24px;
+}
+
+tbody tr td:first-child {
+    display: flex;
+    align-items: center;
+}
+
+tbody tr td {
+    height: 56px;
+}
+</style>

--- a/src/constants/employment/difficulty.js
+++ b/src/constants/employment/difficulty.js
@@ -1,0 +1,17 @@
+/**
+ * 실무테스트 난이도 매핑
+ */
+export const DIFFICULTY_MAP = {
+    'EASY': '쉬움',
+    'MEDIUM': '보통',
+    'HARD': '어려움'
+};
+
+/**
+ * 실무테스트 난이도 한글화
+ * @param {keyof typeof DIFFICULTY_MAP} difficulty - 난이도
+ * @returns {string} 한글화된 난이도
+ */
+export const getDifficultyLabel = (difficulty) => {
+    return DIFFICULTY_MAP[difficulty] || difficulty;
+}; 

--- a/src/constants/employment/questionTypes.js
+++ b/src/constants/employment/questionTypes.js
@@ -1,0 +1,17 @@
+/**
+ * 실무테스트 문제 유형 매핑
+ */
+export const QUESTION_TYPE_MAP = {
+    'MULTIPLE': '선택형',
+    'SUBJECTIVE': '단답형',
+    'DESCRIPTIVE': '서술형'
+};
+
+/**
+ * 실무테스트 문제 유형 한글화
+ * @param {keyof typeof QUESTION_TYPE_MAP} type - 문제 유형
+ * @returns {string} 한글화된 문제 유형
+ */
+export const getQuestionTypeLabel = (type) => {
+    return QUESTION_TYPE_MAP[type] || type;
+}; 

--- a/src/dto/common/ApiResponseDTO.js
+++ b/src/dto/common/ApiResponseDTO.js
@@ -1,0 +1,26 @@
+export default class ApiResponseDTO {
+    constructor(success, code, message, data) {
+        this.success = success;
+        this.code = code;
+        this.message = message;
+        this.data = data;
+    }
+
+    static fromJSON(json) {
+        return new ApiResponseDTO(
+            json.success,
+            json.code,
+            json.message,
+            json.data
+        );
+    }
+
+    toJSON() {
+        return {
+            success: this.success,
+            code: this.code,
+            message: this.message,
+            data: this.data
+        };
+    }
+} 

--- a/src/dto/employment/jobtest/JobtestResponseDTO.js
+++ b/src/dto/employment/jobtest/JobtestResponseDTO.js
@@ -1,0 +1,32 @@
+export default class JobtestResponseDTO {
+    constructor(id, content, type, difficulty, createdMemberId, updatedMemberId) {
+        this.id = id;
+        this.content = content;
+        this.type = type;
+        this.difficulty = difficulty;
+        this.createdMemberId = createdMemberId;
+        this.updatedMemberId = updatedMemberId;
+    }
+
+    static fromJSON(json) {
+        return new JobtestResponseDTO(
+            json.id,
+            json.content,
+            json.type,
+            json.difficulty,
+            json.createdMemberId,
+            json.updatedMemberId
+        );
+    }
+
+    toJSON() {
+        return {
+            id: this.id,
+            content: this.content,
+            type: this.type,
+            difficulty: this.difficulty,
+            createdMemberId: this.createdMemberId,
+            updatedMemberId: this.updatedMemberId
+        };
+    }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -2,6 +2,8 @@ import { createApp } from 'vue'
 import router from './router'
 import { createPinia } from 'pinia'
 import App from './App.vue'
+import Toast from 'vue-toastification'
+import 'vue-toastification/dist/index.css'
 
 import 'vuetify/styles'
 import '@mdi/font/css/materialdesignicons.css'
@@ -21,7 +23,24 @@ const vuetify = createVuetify({
     },
 })
 
+// 토스트 설정
+const toastOptions = {
+    position: 'top-right',
+    timeout: 3000,
+    closeOnClick: true,
+    pauseOnFocusLoss: true,
+    pauseOnHover: true,
+    draggable: true,
+    draggablePercent: 0.6,
+    showCloseButtonOnHover: false,
+    hideProgressBar: false,
+    closeButton: 'button',
+    icon: true,
+    rtl: false
+}
+
 app.use(pinia)
 app.use(router)
 app.use(vuetify)
+app.use(Toast, toastOptions)
 app.mount('#app')

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -97,11 +97,21 @@ const routes = [
         name: 'WSPage',
         component: () => import('@/views/test/WSPage.vue')
     },
+
+    // <-------------------- 실무테스트 -------------------->
     {
         path: '/employment/jobtests',
         name: 'EmploymentJobtests',
         component: () => import('@/views/test/EvaluationTestPage.vue'),
         props: true
+    },
+    {
+        path: '/employment/jobtests/problems',
+        name: 'JobtestProblemList',
+        component: () => import('@/views/employment/JobtestProblemListPage.vue'),
+        meta: {
+            requiresAuth: true
+        }
     },
 ];
 

--- a/src/services/jobtestService.js
+++ b/src/services/jobtestService.js
@@ -2,27 +2,21 @@ import api from '@/apis/apiClient';
 import { JobtestAPI } from '@/apis/routes/jobtest';
 import JobtestResponseDTO from '@/dto/employment/jobtest/JobtestResponseDTO';
 import ApiResponseDTO from '@/dto/common/ApiResponseDTO';
-import { withErrorHandling } from '@/utils/errorHandler';
+import { withErrorHandling, throwCustomApiError } from '@/utils/errorHandler';
 
 /**
  * 실무테스트 문제 목록을 조회하는 서비스
- * @param {Object} options - 에러 처리 옵션
- * @param {boolean} options.showToast - 토스트 메시지 표시 여부 (기본값: true)
- * @param {boolean} options.redirect - 리다이렉트 처리 여부 (기본값: true)
- * @returns {Promise<JobtestResponseDTO[]>} 실무테스트 문제 목록
  */
 export const getQuestionsService = async (options = {}) => {
     return withErrorHandling(async () => {
         const response = await api.get(JobtestAPI.QUESTIONS);
         const apiResponse = ApiResponseDTO.fromJSON(response.data);
 
+        // 성공 상태로 오지 않았다면 에러 처리
         if (!apiResponse.success) {
-            throw new Error(apiResponse.message);
-        } else if (!apiResponse.data) {
-            throw new Error('데이터가 존재하지 않습니다.');
+            throwCustomApiError(apiResponse.code, apiResponse.message, 400);
         }
 
-        // 응답 데이터를 DTO 객체로 변환
-        return apiResponse.data.map(question => JobtestResponseDTO.fromJSON(question));
+        return apiResponse.data.map(item => JobtestResponseDTO.fromJSON(item));
     }, options);
 };

--- a/src/services/jobtestService.js
+++ b/src/services/jobtestService.js
@@ -1,0 +1,28 @@
+import api from '@/apis/apiClient';
+import { JobtestAPI } from '@/apis/routes/jobtest';
+import JobtestResponseDTO from '@/dto/employment/jobtest/JobtestResponseDTO';
+import ApiResponseDTO from '@/dto/common/ApiResponseDTO';
+import { withErrorHandling } from '@/utils/errorHandler';
+
+/**
+ * 실무테스트 문제 목록을 조회하는 서비스
+ * @param {Object} options - 에러 처리 옵션
+ * @param {boolean} options.showToast - 토스트 메시지 표시 여부 (기본값: true)
+ * @param {boolean} options.redirect - 리다이렉트 처리 여부 (기본값: true)
+ * @returns {Promise<JobtestResponseDTO[]>} 실무테스트 문제 목록
+ */
+export const getQuestionsService = async (options = {}) => {
+    return withErrorHandling(async () => {
+        const response = await api.get(JobtestAPI.QUESTIONS);
+        const apiResponse = ApiResponseDTO.fromJSON(response.data);
+
+        if (!apiResponse.success) {
+            throw new Error(apiResponse.message);
+        } else if (!apiResponse.data) {
+            throw new Error('데이터가 존재하지 않습니다.');
+        }
+
+        // 응답 데이터를 DTO 객체로 변환
+        return apiResponse.data.map(question => JobtestResponseDTO.fromJSON(question));
+    }, options);
+};

--- a/src/stores/jobtestStore.js
+++ b/src/stores/jobtestStore.js
@@ -1,0 +1,80 @@
+import { defineStore } from 'pinia';
+import { ref, computed } from 'vue';
+import { getQuestionsService } from '@/services/jobtestService';
+import { getQuestionTypeLabel } from '@/constants/employment/questionTypes';
+import { getDifficultyLabel } from '@/constants/employment/difficulty';
+
+export const useJobtestStore = defineStore('jobtest', () => {
+    // 상태 정의
+    const questions = ref([]);
+    const loading = ref(false);
+    const error = ref(null);
+
+    // 게터
+    const hasSelectedQuestions = computed(() => {
+        return questions.value.some(q => q.selected);
+    });
+
+    // 문제 목록 조회
+    const fetchQuestions = async () => {
+        loading.value = true;
+        error.value = null;
+
+        try {
+            const response = await getQuestionsService();
+            questions.value = response.map(question => ({
+                ...question,
+                selected: false,
+                type: getQuestionTypeLabel(question.type),
+                difficulty: getDifficultyLabel(question.difficulty)
+            }));
+        } catch (err) {
+            error.value = err.message;
+            throw err;
+        } finally {
+            loading.value = false;
+        }
+    };
+
+    // 문제 선택 토글
+    const toggleQuestionSelection = (questionId) => {
+        const question = questions.value.find(q => q.id === questionId);
+        if (question) {
+            question.selected = !question.selected;
+        }
+    };
+
+    // 선택된 문제들 가져오기
+    const getSelectedQuestions = () => {
+        return questions.value.filter(q => q.selected);
+    };
+
+    // 선택된 문제들의 ID 가져오기
+    const getSelectedQuestionIds = () => {
+        return questions.value
+            .filter(q => q.selected)
+            .map(q => q.id);
+    };
+
+    // 모든 선택 해제
+    const clearSelection = () => {
+        questions.value.forEach(q => q.selected = false);
+    };
+
+    return {
+        // 상태
+        questions,
+        loading,
+        error,
+
+        // 게터
+        hasSelectedQuestions,
+
+        // 액션
+        fetchQuestions,
+        toggleQuestionSelection,
+        getSelectedQuestions,
+        getSelectedQuestionIds,
+        clearSelection
+    };
+}); 

--- a/src/utils/errorHandler.js
+++ b/src/utils/errorHandler.js
@@ -1,0 +1,82 @@
+import ApiResponseDTO from '@/dto/common/ApiResponseDTO';
+import router from '@/router';
+import { useToast } from 'vue-toastification';
+
+const toast = useToast();
+
+/**
+ * API 에러를 처리하는 공통 핸들러
+ * @param {Error} error - 발생한 에러 객체
+ * @param {Object} options - 추가 옵션
+ * @param {boolean} options.showToast - 토스트 메시지 표시 여부 (기본값: true)
+ * @param {boolean} options.redirect - 리다이렉트 처리 여부 (기본값: true)
+ * @returns {void}
+ */
+export const handleApiError = (error, options = { showToast: true, redirect: true }) => {
+    const { showToast = true, redirect = true } = options;
+
+    if (error.response) {
+        // 백엔드에서 반환한 에러 응답 처리
+        const apiResponse = ApiResponseDTO.fromJSON(error.response.data);
+
+        // 에러 로깅
+                console.error('API Error:', {
+            code: apiResponse.code,
+            message: apiResponse.message,
+            status: error.response.status,
+            path: error.config?.url
+        });
+
+        // HTTP 상태 코드에 따른 특별 처리
+        if (redirect) {
+            switch (error.response.status) {
+                case 401:
+                    // 인증 에러 - 로그인 페이지로 리다이렉트
+                    router.push('/login');
+                    break;
+                case 403:
+                    // 권한 없음 - 접근 거부 페이지로 리다이렉트
+                    router.push('/access-denied');
+                    break;
+                case 404:
+                    // 리소스 없음 - 404 페이지로 리다이렉트
+                    router.push('/not-found');
+                    break;
+                // 필요한 경우 다른 상태 코드에 대한 처리 추가
+            }
+        }
+
+        // 토스트 메시지 표시
+        if (showToast) {
+            toast.error(apiResponse.message);
+        }
+
+    } else if (error.request) {
+        // 네트워크 오류 처리
+        console.error('Network Error:', error.request);
+        if (showToast) {
+            toast.error('서버와의 통신에 실패했습니다.');
+        }
+    } else {
+        // 기타 에러 처리
+        console.error('Error:', error.message);
+        if (showToast) {
+            toast.error('알 수 없는 오류가 발생했습니다.');
+        }
+    }
+};
+
+/**
+ * API 에러를 처리하고 결과를 반환하는 래퍼 함수
+ * @param {Function} apiCall - API 호출 함수
+ * @param {Object} options - 에러 처리 옵션
+ * @returns {Promise<any>} API 호출 결과
+ */
+export const withErrorHandling = async (apiCall, options = {}) => {
+    try {
+        return await apiCall();
+    } catch (error) {
+        handleApiError(error, options);
+        throw error; // 에러를 다시 throw하여 호출자가 처리할 수 있도록 함
+    }
+}; 

--- a/src/views/employment/JobtestProblemListPage.vue
+++ b/src/views/employment/JobtestProblemListPage.vue
@@ -1,0 +1,81 @@
+<template>
+    <v-app>
+        <v-main>
+            <v-container class="pa-6">
+                <h2 class="text-h6 font-weight-bold mb-4">실무 테스트 문제 리스트</h2>
+
+                <JobtestListView :headers="headers" :items="items" :showCheckbox="true" :showArrow="true" />
+
+                <div class="d-flex justify-end mt-4">
+                    <v-btn color="error" variant="outlined" class="mr-2">삭제하기</v-btn>
+                    <v-btn color="success">문제 등록하기</v-btn>
+                </div>
+            </v-container>
+        </v-main>
+    </v-app>
+</template>
+
+<script setup>
+import JobtestListView from '@/components/employment/JobtestListView.vue'
+
+const headers = [
+    { label: '문제 제목', key: 'title' },
+    { label: '유형', key: 'type' },
+    { label: '난이도', key: 'difficulty' },
+    { label: '출제자', key: 'author', type: 'avatar' },
+    { label: '채용 수정자', key: 'editor', type: 'avatar' },
+]
+
+const items = [
+    {
+        title: 'Big-O 표기법에 대한 설명으로 옳은것은?',
+        type: '선택형',
+        difficulty: '쉬움',
+        author: { name: '김현식', avatar: 'https://randomuser.me/api/portraits/men/1.jpg' },
+        editor: { name: '박수정', avatar: 'https://randomuser.me/api/portraits/women/1.jpg' },
+        selected: false,
+    },
+    {
+        title: 'TCP와 UDP의 설명으로 옳지 않은 것은?',
+        type: '선택형',
+        difficulty: '어려움',
+        author: { name: '김현식', avatar: 'https://randomuser.me/api/portraits/men/1.jpg' },
+        editor: { name: '박수정', avatar: 'https://randomuser.me/api/portraits/women/1.jpg' },
+        selected: true,
+    },
+    {
+        title: '다음 중 비선점형 스케줄링 알고리즘은?',
+        type: '선택형',
+        difficulty: '보통',
+        author: { name: '김현식', avatar: 'https://randomuser.me/api/portraits/men/1.jpg' },
+        editor: { name: '박수정', avatar: 'https://randomuser.me/api/portraits/women/1.jpg' },
+        selected: false,
+    },
+    {
+        title: '해시 테이블에서 충돌이 발생하는 이유를 설명하고, 이를 해결하는 방법은?',
+        type: '서술형',
+        difficulty: '쉬움',
+        author: { name: '김현식', avatar: 'https://randomuser.me/api/portraits/men/1.jpg' },
+        editor: { name: '박수정', avatar: 'https://randomuser.me/api/portraits/women/1.jpg' },
+        selected: false,
+    },
+    {
+        title: '스택(Stack) 자료구조의 연산 순서는 무엇인가요?',
+        type: '서술형',
+        difficulty: '쉬움',
+        author: { name: '김현식', avatar: 'https://randomuser.me/api/portraits/men/1.jpg' },
+        editor: { name: '박수정', avatar: 'https://randomuser.me/api/portraits/women/1.jpg' },
+        selected: false,
+    },
+    {
+        title: '프로세스와 스레드의 차이점을 설명하고, 스레드 기반 프로그램의 장단점은?',
+        type: '단답형',
+        difficulty: '쉬움',
+        author: { name: '김현식', avatar: 'https://randomuser.me/api/portraits/men/1.jpg' },
+        editor: { name: '박수정', avatar: 'https://randomuser.me/api/portraits/women/1.jpg' },
+        selected: false,
+    },
+]
+</script>
+
+<style scoped></style>

--- a/src/views/employment/JobtestProblemListPage.vue
+++ b/src/views/employment/JobtestProblemListPage.vue
@@ -4,11 +4,29 @@
             <v-container class="pa-6">
                 <h2 class="text-h6 font-weight-bold mb-4">실무 테스트 문제 리스트</h2>
 
-                <JobtestListView :headers="headers" :items="items" :showCheckbox="true" :showArrow="true" />
+                <!-- 로딩 상태 -->
+                <v-progress-circular v-if="jobtestStore.loading" indeterminate color="primary"
+                    class="d-flex mx-auto my-4"></v-progress-circular>
+
+                <!-- 에러 메시지 -->
+                <v-alert v-if="jobtestStore.error" type="error" class="mb-4" closable
+                    @click:close="jobtestStore.error = null">
+                    {{ jobtestStore.error }}
+                </v-alert>
+
+                <!-- 문제 리스트 -->
+                <JobtestListView v-if="!jobtestStore.loading && !jobtestStore.error" :headers="headers"
+                    :items="jobtestStore.questions" :showCheckbox="true" :showArrow="true"
+                    @item-click="handleItemClick" />
 
                 <div class="d-flex justify-end mt-4">
-                    <v-btn color="error" variant="outlined" class="mr-2">삭제하기</v-btn>
-                    <v-btn color="success">문제 등록하기</v-btn>
+                    <v-btn color="error" variant="outlined" class="mr-2" :disabled="!jobtestStore.hasSelectedQuestions"
+                        @click="handleDelete">
+                        삭제하기
+                    </v-btn>
+                    <v-btn color="success" @click="handleCreate">
+                        문제 등록하기
+                    </v-btn>
                 </div>
             </v-container>
         </v-main>
@@ -16,66 +34,48 @@
 </template>
 
 <script setup>
+import { onMounted } from 'vue'
+import { useRouter } from 'vue-router'
 import JobtestListView from '@/components/employment/JobtestListView.vue'
+import { useJobtestStore } from '@/stores/jobtestStore'
+
+const router = useRouter()
+const jobtestStore = useJobtestStore()
 
 const headers = [
-    { label: '문제 제목', key: 'title' },
+    { label: '문제 제목', key: 'content' },
     { label: '유형', key: 'type' },
     { label: '난이도', key: 'difficulty' },
-    { label: '출제자', key: 'author', type: 'avatar' },
-    { label: '채용 수정자', key: 'editor', type: 'avatar' },
+    { label: '출제자', key: 'createdMemberId' },
+    { label: '수정자', key: 'updatedMemberId' },
 ]
 
-const items = [
-    {
-        title: 'Big-O 표기법에 대한 설명으로 옳은것은?',
-        type: '선택형',
-        difficulty: '쉬움',
-        author: { name: '김현식', avatar: 'https://randomuser.me/api/portraits/men/1.jpg' },
-        editor: { name: '박수정', avatar: 'https://randomuser.me/api/portraits/women/1.jpg' },
-        selected: false,
-    },
-    {
-        title: 'TCP와 UDP의 설명으로 옳지 않은 것은?',
-        type: '선택형',
-        difficulty: '어려움',
-        author: { name: '김현식', avatar: 'https://randomuser.me/api/portraits/men/1.jpg' },
-        editor: { name: '박수정', avatar: 'https://randomuser.me/api/portraits/women/1.jpg' },
-        selected: true,
-    },
-    {
-        title: '다음 중 비선점형 스케줄링 알고리즘은?',
-        type: '선택형',
-        difficulty: '보통',
-        author: { name: '김현식', avatar: 'https://randomuser.me/api/portraits/men/1.jpg' },
-        editor: { name: '박수정', avatar: 'https://randomuser.me/api/portraits/women/1.jpg' },
-        selected: false,
-    },
-    {
-        title: '해시 테이블에서 충돌이 발생하는 이유를 설명하고, 이를 해결하는 방법은?',
-        type: '서술형',
-        difficulty: '쉬움',
-        author: { name: '김현식', avatar: 'https://randomuser.me/api/portraits/men/1.jpg' },
-        editor: { name: '박수정', avatar: 'https://randomuser.me/api/portraits/women/1.jpg' },
-        selected: false,
-    },
-    {
-        title: '스택(Stack) 자료구조의 연산 순서는 무엇인가요?',
-        type: '서술형',
-        difficulty: '쉬움',
-        author: { name: '김현식', avatar: 'https://randomuser.me/api/portraits/men/1.jpg' },
-        editor: { name: '박수정', avatar: 'https://randomuser.me/api/portraits/women/1.jpg' },
-        selected: false,
-    },
-    {
-        title: '프로세스와 스레드의 차이점을 설명하고, 스레드 기반 프로그램의 장단점은?',
-        type: '단답형',
-        difficulty: '쉬움',
-        author: { name: '김현식', avatar: 'https://randomuser.me/api/portraits/men/1.jpg' },
-        editor: { name: '박수정', avatar: 'https://randomuser.me/api/portraits/women/1.jpg' },
-        selected: false,
-    },
-]
+// 문제 클릭 처리
+const handleItemClick = (item) => {
+    jobtestStore.toggleQuestionSelection(item.id)
+}
+
+// 삭제 처리
+const handleDelete = () => {
+    const selectedIds = jobtestStore.getSelectedQuestionIds()
+    console.log('Selected questions:', selectedIds)
+    // TODO: 선택된 문제 삭제 로직 구현
+}
+
+// 문제 등록
+const handleCreate = () => {
+    // TODO: 문제 등록 페이지로 이동
+    console.log('Create new question')
+}
+
+// 컴포넌트 마운트 시 문제 목록 조회
+onMounted(async () => {
+    try {
+        await jobtestStore.fetchQuestions()
+    } catch (error) {
+        console.error('Failed to fetch questions:', error)
+    }
+})
 </script>
 
 <style scoped></style>


### PR DESCRIPTION
### 🪄 PR 타입

- [X] 신규 기능
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] 버그 픽스

### #️⃣ 연관된 이슈

close #이슈번호

### 📝 변경 사항
- 공통 에러 핸들러 개발
- 실무테스트 문제 목록 페이지 구현
- 401 에러 발생 시 로그아웃 후 로그인 페이지로 강제 이동

---

아래 내용은 없을 경우 삭제하면 됩니다.

### 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분
- 백엔드에서 처리한 에러 상황이 프론트로 넘어오는 경우를 처리하는 에러 핸들러를 만들었습니다.
사용하는 방식은 아래와 같습니다. (`jobtestService.js` 에 있는 코드)
```
export const getQuestionsService = async (options = {}) => {
    return withErrorHandling(async () => {
        const response = await api.get(JobtestAPI.QUESTIONS);
        const apiResponse = ApiResponseDTO.fromJSON(response.data);

        // 성공 상태로 오지 않았다면 에러 처리
        if (!apiResponse.success) {
            throwCustomApiError(apiResponse.code, apiResponse.message, 400);
        }

        return apiResponse.data.map(item => JobtestResponseDTO.fromJSON(item));
    }, options);
};
```
- 아직 403, 404 에러를 처리하는 페이지는 따로 만들지 않았습니다. 참고 부탁드립니다.
- 에러 처리하는 기능은 우선 토스트로 구현했습니다. 추후에 디자인.. 수정이 필요할 것 같습니다..

### 📷 관련 스크린샷
- 실무테스트 문제 목록 페이지
![image](https://github.com/user-attachments/assets/ea10487e-dcfb-4698-a970-d47f88915652)

- 에러 상황 발생
![image](https://github.com/user-attachments/assets/a6fd2f7d-ac75-492a-9223-0d2e16b45d6e)


### 🧪 테스트 계획 또는 완료 사항

- [ ] [실무테스트 문제 목록 페이지](http://localhost:8080/employment/jobtests/problems)
