### PR TITLE
[refactor] 사이드바, 헤더에서 사용할 경로 라우터에서 가져오기

### DIFF
--- a/src/components/common/MainSidebar.vue
+++ b/src/components/common/MainSidebar.vue
@@ -24,7 +24,7 @@
                         </template>
 
                         <v-list-item v-for="(subItem, j) in section.children" :key="j" :title="subItem.label"
-                            :to="subItem.path" link :active="route.path === subItem.path" class="menu-item"
+                            :to="subItem.path" link :active="route.path === subItem.path || route.path.startsWith(subItem.path)" class="menu-item"
                             active-class="active-item" />
                     </v-list-group>
                 </template>

--- a/src/json/fullMenu.js
+++ b/src/json/fullMenu.js
@@ -1,3 +1,5 @@
+import { routeMap } from '@/router/index.js';
+
 // 메뉴 구조
 export const fullMenu = {
     내정보: [
@@ -64,11 +66,9 @@ export const fullMenu = {
             label: "실무테스트 관리",
             role: ["인사팀"],
             children: [
-                { label: "실무테스트 유형", path: "/employment/jobtest-types" },
-                { label: "실무테스트 템플릿", path: "/employment/jobtest-templates" },
-                { label: "실무테스트 문제", path: "/employment/jobtest-questions" },
-                { label: "실무테스트", path: "/employment/jobtests" },
-                { label: "실무테스트 답안", path: "/employment/jobtest-answers" }
+                { label: "실무테스트 문제", path: routeMap.JobtestQuestionList },
+                { label: "실무테스트", path: routeMap.JobtestList },
+                { label: "실무테스트 답안", path: routeMap.JobtestAnswerList }
             ]
         },
         {

--- a/src/router/employment.routes.js
+++ b/src/router/employment.routes.js
@@ -7,21 +7,79 @@ export const employmentRoutes = [
             requiresAuth: true
         }
     },
+
+    //    <------------------- 실무테스트 -------------------->
+    // 실무테스트 문제 목록 페이지
     {
-        path: '/employment/jobtests',
-        name: 'EmploymentJobtests',
-        component: () => import('@/views/test/EvaluationTestPage.vue'),
-        props: true,
-        meta: {
-            requiresAuth: true
-        }
-    },
-    {
-        path: '/employment/jobtests/questions',
+        path: '/employment/jobtest-questions',
         name: 'JobtestQuestionList',
         component: () => import('@/views/employment/JobtestQuestionListPage.vue'),
         meta: {
             requiresAuth: true
         }
+    },
+    // 실무테스트 문제 등록 페이지
+    {
+        path: '/employment/jobtest-questions/create',
+        name: 'JobtestQuestionCreate',
+        component: () => import('@/views/employment/JobtestQuestionCreatePage.vue'),
+        meta: {
+            requiresAuth: true
+        }
+    },
+
+    // 실무테스트 목록 페이지
+    {
+        path: '/employment/jobtests',
+        name: 'JobtestList',
+        component: () => import('@/views/employment/JobtestListPage.vue'),
+        meta: { requiresAuth: true }
+    },
+    // 실무테스트 상세 조회 페이지
+    {
+        path: '/employment/jobtests/:id',
+        name: 'JobtestDetail',
+        component: () => import('@/views/employment/JobtestDetailPage.vue'),
+        props: true,
+        meta: { requiresAuth: true }
+    },
+    // 실무테스트 등록 페이지
+    {
+        path: '/employment/jobtests/create',
+        name: 'JobtestCreate',
+        component: () => import('@/views/employment/JobtestCreatePage.vue'),
+        meta: { requiresAuth: true }
+    },
+
+    // 실무테스트 답안 목록 페이지
+    {
+        path: '/employment/jobtest-answers',
+        name: 'JobtestAnswerList',
+        component: () => import('@/views/employment/JobtestAnswerListPage.vue'),
+        meta: { requiresAuth: true }
+    },
+    // 실무테스트 답안 상세 조회 페이지
+    {
+        path: '/employment/jobtest-answers/:answerId',
+        name: 'JobtestAnswerDetail',
+        component: () => import('@/views/employment/JobtestAnswerDetailPage.vue'),
+        props: true,
+        meta: { requiresAuth: true }
+    },
+    // 실무테스트 답안 채점 페이지
+    {
+        path: '/employment/jobtest-answers/:answerId/grading',
+        name: 'JobtestAnswerGrading',
+        component: () => import('@/views/employment/JobtestAnswerGradingPage.vue'),
+        props: true,
+        meta: { requiresAuth: true }
+    },
+    // 실무테스트 답안 평가 등록 페이지
+    {
+        path: '/employment/jobtest-answers/:answerId/evaluation',
+        name: 'JobtestAnswerEvaluation',
+        component: () => import('@/views/employment/JobtestAnswerEvaluationPage.vue'),
+        props: true,
+        meta: { requiresAuth: true }
     }
 ]; 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -5,6 +5,20 @@ import { orgstructureRoutes } from './orgstructure.routes';
 import { testRoutes } from './test.routes';
 import { authGuard } from './middleware/auth.guard';
 
+const allRouteModules = [
+    ...authRoutes,
+    ...employmentRoutes,
+    ...orgstructureRoutes,
+    ...(process.env.NODE_ENV === 'development' ? testRoutes : [])
+];
+
+// fullMenu.js 에서 사용하기 위해
+export const routeMap = Object.fromEntries(
+    allRouteModules
+        .filter(route => route.name && route.path)
+        .map(route => [route.name, route.path])
+);
+
 const routes = [
     {
         path: '/',
@@ -22,10 +36,7 @@ const routes = [
             requiresAuth: true
         }
     },
-    ...authRoutes,
-    ...employmentRoutes,
-    ...orgstructureRoutes,
-    ...(process.env.NODE_ENV === 'development' ? testRoutes : [])
+    ...allRouteModules
 ];
 
 const router = createRouter({

--- a/src/views/employment/JobtestAnswerDetailPage.vue
+++ b/src/views/employment/JobtestAnswerDetailPage.vue
@@ -1,0 +1,11 @@
+<template>
+    <div>
+
+    </div>
+</template>
+
+<script setup>
+
+</script>
+
+<style scoped></style>

--- a/src/views/employment/JobtestAnswerEvaluationPage.vue
+++ b/src/views/employment/JobtestAnswerEvaluationPage.vue
@@ -1,0 +1,11 @@
+<template>
+    <div>
+
+    </div>
+</template>
+
+<script setup>
+
+</script>
+
+<style scoped></style>

--- a/src/views/employment/JobtestAnswerGradingPage.vue
+++ b/src/views/employment/JobtestAnswerGradingPage.vue
@@ -1,0 +1,11 @@
+<template>
+    <div>
+
+    </div>
+</template>
+
+<script setup>
+
+</script>
+
+<style scoped></style>

--- a/src/views/employment/JobtestAnswerListPage.vue
+++ b/src/views/employment/JobtestAnswerListPage.vue
@@ -1,0 +1,11 @@
+<template>
+    <div>
+
+    </div>
+</template>
+
+<script setup>
+
+</script>
+
+<style scoped></style>

--- a/src/views/employment/JobtestCreatePage.vue
+++ b/src/views/employment/JobtestCreatePage.vue
@@ -1,0 +1,11 @@
+<template>
+    <div>
+
+    </div>
+</template>
+
+<script setup>
+
+</script>
+
+<style scoped></style>

--- a/src/views/employment/JobtestDetailPage.vue
+++ b/src/views/employment/JobtestDetailPage.vue
@@ -1,0 +1,11 @@
+<template>
+    <div>
+
+    </div>
+</template>
+
+<script setup>
+
+</script>
+
+<style scoped></style>

--- a/src/views/employment/JobtestListPage.vue
+++ b/src/views/employment/JobtestListPage.vue
@@ -1,0 +1,11 @@
+<template>
+    <div>
+
+    </div>
+</template>
+
+<script setup>
+
+</script>
+
+<style scoped></style>

--- a/src/views/employment/JobtestQuestionCreatePage.vue
+++ b/src/views/employment/JobtestQuestionCreatePage.vue
@@ -1,0 +1,11 @@
+<template>
+    <div>
+
+    </div>
+</template>
+
+<script setup>
+
+</script>
+
+<style scoped></style>


### PR DESCRIPTION
### 🪄 PR 타입

- [ ] 신규 기능
- [ ] 기능 수정
- [X] 리팩토링
- [ ] 버그 픽스

### #️⃣ 연관된 이슈

close #이슈번호

### 📝 변경 사항
- 사이드바, 헤더에서 사용해야 할 경로 라우터에서 가져오게 수정
- 실무테스트 페이지 파일 생성

---

### 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분

- 라우터에 등록한 경로 name을 fullMenu.js의 path에서 사용하시면 됩니다.
- fullMenu.js에 등록한 경로로 시작하면 같은 메뉴로 처리됩니다.

### 📷 관련 스크린샷

**employment.routes.js**
![image](https://github.com/user-attachments/assets/4cc5f4e4-b45d-402a-8fc7-b8698b346e83)

**fullMenu.js**
`routeMap.JobtestQuestionList`(`/employment/jobtest-questions`) 를 path로 설정함
![image](https://github.com/user-attachments/assets/8c5b7323-46ec-4dc3-8dc3-d7c3a1855cf2)

`/employment/jobtest-questions` 경로와 `/employment/jobtest-questions/create` 모두 실무테스트 문제로 표시
![image](https://github.com/user-attachments/assets/a2900d9e-c473-44d8-a4e4-b7e5d52869fd)
![image](https://github.com/user-attachments/assets/c4088021-db75-4b15-a10a-3a01781834dc)


### 🧪 테스트 계획 또는 완료 사항

- [ ] [실무테스트 문제 목록](http://localhost:8080/employment/jobtest-questions)
- [ ] [실무테스트 문제 등록(경로 확인용. 아직 페이지 개발 X)
](http://localhost:8080/employment/jobtest-questions/create)