### PR TITLE
[feat] 실무테스트 목록 조회 페이지 구현

### DIFF
--- a/src/dto/employment/jobtest/jobtestListResponseDTO.js
+++ b/src/dto/employment/jobtest/jobtestListResponseDTO.js
@@ -1,0 +1,36 @@
+export default class JobtestListResponseDTO {
+    constructor(id, title, difficulty, createdId, createdName, updatedId, updatedName
+    ) {
+        this.id = id;
+        this.title = title;
+        this.difficulty = difficulty;
+        this.createdId = createdId;
+        this.createdName = createdName;
+        this.updatedId = updatedId;
+        this.updatedName = updatedName;
+    }
+
+    static fromJSON(json) {
+        return new JobtestListResponseDTO(
+            json.id,
+            json.title,
+            json.difficulty,
+            json.createdId,
+            json.createdName,
+            json.updatedId,
+            json.updatedName
+        );
+    }
+
+    toJSON() {
+        return {
+            id: this.id,
+            title: this.title,
+            difficulty: this.difficulty,
+            createdId: this.createdId,
+            createdName: this.createdName,
+            updatedId: this.updatedId,
+            updatedName: this.updatedName
+        };
+    }
+}

--- a/src/services/jobtestService.js
+++ b/src/services/jobtestService.js
@@ -1,0 +1,20 @@
+import api from '@/apis/apiClient';
+import { JobtestAPI } from '@/apis/routes/jobtest';
+import { withErrorHandling, throwCustomApiError } from '@/utils/errorHandler';
+import ApiResponseDTO from '@/dto/common/apiResponseDTO';
+import JobtestListResponseDTO from '@/dto/employment/jobtest/jobtestListResponseDTO';
+
+// 실무테스트 목록 조회 서비스
+export const getQuestionsService = async (options = {}) => {
+    return withErrorHandling(async () => {
+        const response = await api.get(JobtestAPI.JOBTESTS);
+        const apiResponse = ApiResponseDTO.fromJSON(response.data);
+
+        // 성공 상태로 오지 않았다면 에러 처리
+        if (!apiResponse.success) {
+            throwCustomApiError(apiResponse.code, apiResponse.message, 400);
+        }
+
+        return apiResponse.data.map(item => JobtestListResponseDTO.fromJSON(item));
+    }, options);
+};

--- a/src/stores/jobtestListStore.js
+++ b/src/stores/jobtestListStore.js
@@ -1,0 +1,49 @@
+import { defineStore } from 'pinia';
+import { ref, computed } from 'vue';
+import { getQuestionsService } from '@/services/jobtestService';
+import { getDifficultyLabel } from '@/constants/employment/difficulty';
+
+export const useJobtestListStore = defineStore('jobtestList', () => {
+    const jobtests = ref([]);
+    const selectedIds = ref([]);
+    const loading = ref(false);
+    const error = ref(null);
+
+    const hasSelectedJobtests = computed(() => selectedIds.value.length > 0);
+
+    const fetchJobtests = async () => {
+        loading.value = true;
+        error.value = null;
+        try {
+            const response = await getQuestionsService(); // ✅ 서비스 사용
+            jobtests.value = response.map(item => ({
+                ...item,
+                difficulty: getDifficultyLabel(item.difficulty)
+            }));
+        } catch (e) {
+            error.value = e.message || '실무 테스트 목록 로딩 실패';
+            throw e;
+        } finally {
+            loading.value = false;
+        }
+    };
+
+    const toggleSelection = (id) => {
+        const index = selectedIds.value.indexOf(id);
+        if (index >= 0) selectedIds.value.splice(index, 1);
+        else selectedIds.value.push(id);
+    };
+
+    const clearSelection = () => selectedIds.value.splice(0);
+
+    return {
+        jobtests,
+        selectedIds,
+        loading,
+        error,
+        hasSelectedJobtests,
+        fetchJobtests,
+        toggleSelection,
+        clearSelection
+    };
+});

--- a/src/views/employment/JobtestListPage.vue
+++ b/src/views/employment/JobtestListPage.vue
@@ -1,11 +1,58 @@
 <template>
-    <div>
+    <v-app>
+        <v-main>
+            <v-container class="pa-6">
+                <h2 class="text-h6 font-weight-bold mb-4">실무 테스트 리스트</h2>
 
-    </div>
+                <v-progress-circular v-if="store.loading" indeterminate color="primary" class="mx-auto my-4" />
+                <v-alert v-if="store.error" type="error" class="mb-4" closable @click:close="store.error = null">
+                    {{ store.error }}
+                </v-alert>
+
+                <ListView :headers="headers" :data="store.jobtests" :showCheckbox="true"
+                    @item-click="handleItemClick" />
+
+                <div class="d-flex justify-end mt-4">
+                    <v-btn color="error" variant="outlined" class="mr-2" :disabled="!store.hasSelectedJobtests"
+                        @click="handleDelete">삭제하기</v-btn>
+                    <v-btn color="success" @click="handleCreate">실무 테스트 등록하기</v-btn>
+                </div>
+            </v-container>
+        </v-main>
+    </v-app>
 </template>
 
+
 <script setup>
+import { onMounted } from 'vue';
+import { useRouter } from 'vue-router';
+import ListView from '@/components/common/ListView.vue';
+import { useJobtestListStore } from '@/stores/jobtestListStore';
 
+const router = useRouter();
+const store = useJobtestListStore();
+
+const headers = [
+    { label: '제목', key: 'title' },
+    { label: '난이도', key: 'difficulty' },
+    { label: '출제자', key: 'createdName' },
+    { label: '수정자', key: 'updatedName' }
+];
+
+const handleItemClick = (item) => {
+    store.toggleSelection(item.id);
+};
+
+const handleCreate = () => {
+    router.push({ name: 'JobtestCreate' });
+};
+
+const handleDelete = () => {
+    console.log('선택된 ID:', store.selectedIds);
+    // TODO: 삭제 연동
+};
+
+onMounted(async () => {
+    await store.fetchJobtests();
+});
 </script>
-
-<style scoped></style>


### PR DESCRIPTION
### 🪄 PR 타입

- [X] 신규 기능
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] 버그 픽스

### #️⃣ 연관된 이슈
close #68


### 📝 변경 사항
- 실무테스트 목록 조회 페이지 구현

### 💭 참고 사항
- 아래 링크를 머지하거나 fix/sh/jobtest_query 브랜치에 체크아웃한 후에 테스트해야 오류가 안생깁니다.
https://github.com/Pive-Guyz/be14-fin-Empick-BE/pull/249

---



### 📷 관련 스크린샷
![{8E3BBD03-B192-4310-919E-16F58A16C711}](https://github.com/user-attachments/assets/507d720b-fa71-4098-8291-54ff5ac96d60)


### 🧪 테스트 계획 또는 완료 사항
- [ ]  [실무테스트 목록 페이지](http://localhost:8080/employment/jobtests)
