### PR TITLE
[featire] 문제 상세 조회 페이지 구현

### DIFF
--- a/src/components/employment/JobtestQuestionDetailModal.vue
+++ b/src/components/employment/JobtestQuestionDetailModal.vue
@@ -1,0 +1,148 @@
+<template>
+  <v-container class="pa-6">
+    <h2 class="text-h6 font-weight-bold mb-4">문제 상세 정보</h2>
+
+    <!-- 문제 기본 정보 -->
+    <v-card class="mb-4" variant="outlined">
+      <v-card-text>
+        <div><strong>문제 내용:</strong> {{ question.content }}</div>
+        <div v-if="question.detailContent"><strong>상세 설명:</strong> {{ question.detailContent }}</div>
+        <div>
+          <strong>유형:</strong> {{ getQuestionTypeLabel(question.type) }}
+          &nbsp;&nbsp;
+          <strong>난이도:</strong> {{ getDifficultyLabel(question.difficulty) }}
+        </div>
+        <div v-if="question.answer"><strong>정답:</strong> {{ question.answer }}</div>
+      </v-card-text>
+    </v-card>
+
+    <!-- 선지 -->
+    <v-card v-if="question.options && question.options.length" class="mb-4" variant="tonal">
+      <v-card-title>선택지</v-card-title>
+      <v-list>
+        <v-list-item v-for="(opt, i) in question.options" :key="i">
+          <v-list-item-content>
+            <v-list-item-title>
+              {{ opt.optionNumber ? `${opt.optionNumber}. ` : '' }}{{ opt.content }}
+            </v-list-item-title>
+          </v-list-item-content>
+        </v-list-item>
+      </v-list>
+    </v-card>
+
+    <!-- 채점 기준 -->
+    <v-card v-if="question.gradingCriteria && question.gradingCriteria.length" class="mb-4" variant="tonal">
+      <v-card-title>채점 기준</v-card-title>
+      <v-simple-table>
+        <thead>
+          <tr>
+            <th>기준 내용</th>
+            <th>가중치</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="(criteria, i) in question.gradingCriteria" :key="i">
+            <td>{{ criteria.content }}</td>
+            <td>{{ criteria.scoreWeight }}</td>
+          </tr>
+        </tbody>
+      </v-simple-table>
+    </v-card>
+
+    <!-- 사용중인 실무테스트 -->
+    <v-card v-if="question.usedJobTests && question.usedJobTests.length" class="mb-4" variant="tonal">
+      <v-card-title>이 문제를 사용하는 실무 테스트</v-card-title>
+      <v-list>
+        <v-list-item v-for="(test, i) in question.usedJobTests" :key="i">
+          <v-list-item-content>
+            <v-list-item-title>
+              {{ test.title }} (ID: {{ test.id }})
+            </v-list-item-title>
+          </v-list-item-content>
+        </v-list-item>
+      </v-list>
+    </v-card>
+
+    <!-- 생성/수정 정보 -->
+    <div class="mt-4">
+      <v-row>
+        <v-col cols="6"><strong>생성자:</strong> {{ question.createdMemberName }} (ID: {{ question.createdMemberId }})</v-col>
+        <v-col cols="6"><strong>생성일:</strong> {{ formatDate(question.createdAt) }}</v-col>
+      </v-row>
+      <v-row>
+        <v-col cols="6" v-if="question.updatedMemberId"><strong>최종 수정자:</strong> {{ question.updatedMemberName }} (ID: {{ question.updatedMemberId }})</v-col>
+        <v-col cols="6" v-if="question.updatedAt"><strong>최종 수정일:</strong> {{ formatDate(question.updatedAt) }}</v-col>
+      </v-row>
+    </div>
+  </v-container>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue';
+import QuestionQueryDTO from '@/dto/QuestionQueryDTO'; // 한 파일에 모두 정의된 구조
+
+// 실제로는 API에서 받아온 데이터를 사용
+const mockApiResponse = {
+  id: 1,
+  content: 'Big-O 표기법에 대한 설명으로 옳은것은?',
+  detailContent: '',
+  type: 'MULTIPLE',
+  difficulty: 'EASY',
+  answer: 'O(1)은 입력 크기에 영향을 받는다.',
+  createdMemberId: 1,
+  createdMemberName: '김현식',
+  updatedMemberId: 2,
+  updatedMemberName: '박수정',
+  createdAt: '2025-05-22T05:23:00',
+  updatedAt: '2025-05-26T12:44:00',
+  options: [
+    { optionNumber: 1, content: 'O(1)은 입력 크기에 영향을 받는다.' },
+    { optionNumber: 2, content: 'O(n)은 입력 크기가 증가하면 시간은 제곱으로 증가한다.' },
+    { optionNumber: 3, content: 'O(log n)은 입력 크기가 늘어나도 시간은 선형적으로 증가한다.' },
+    { optionNumber: 4, content: 'O(n²)는 최악의 경우에만 적용된다.' }
+  ],
+  usedJobTests: [
+    { id: 101, title: '2024 하반기 현장실습인턴 - IT 직무' },
+    { id: 102, title: '2025 하반기 현장실습인턴 - IT 직무_A그룹' }
+  ],
+  gradingCriteria: [
+    { content: '정확하게 O(1)의 정의를 서술', scoreWeight: 1 }
+  ]
+};
+
+const question = ref(null);
+
+onMounted(() => {
+  // 실제로는 API 호출 후 받아온 데이터에서 변환
+  question.value = QuestionQueryDTO.fromJSON(mockApiResponse);
+});
+
+// 라벨 변환 함수들 (프로젝트별 상수/유틸 활용 가능)
+function getQuestionTypeLabel(type) {
+  switch (type) {
+    case 'MULTIPLE': return '선택형';
+    case 'SUBJECTIVE': return '단답형';
+    case 'DESCRIPTIVE': return '서술형';
+    default: return type;
+  }
+}
+function getDifficultyLabel(diff) {
+  switch (diff) {
+    case 'EASY': return '쉬움';
+    case 'MEDIUM': return '보통';
+    case 'HARD': return '어려움';
+    default: return diff;
+  }
+}
+function formatDate(dateStr) {
+  if (!dateStr) return '';
+  const d = new Date(dateStr);
+  return `${d.getFullYear()}-${(d.getMonth()+1).toString().padStart(2,'0')}-${d.getDate().toString().padStart(2,'0')} ${d.getHours().toString().padStart(2,'0')}:${d.getMinutes().toString().padStart(2,'0')}`;
+}
+</script>
+
+<style scoped>
+.v-card {
+  border-radius: 16px;
+}
+</style>

--- a/src/dto/employment/jobtest/answerResponseDTO.js
+++ b/src/dto/employment/jobtest/answerResponseDTO.js
@@ -1,0 +1,120 @@
+// AnswerQueryDTO.js
+
+// 1. GradingResultDTO
+// class GradingResultDTO {
+//     constructor(id, gradingCriteriaId, isSatisfied, answerId) {
+//         this.id = id;
+//         this.gradingCriteriaId = gradingCriteriaId;
+//         this.isSatisfied = isSatisfied; // Boolean
+//         this.answerId = answerId;
+//     }
+
+//     static fromJSON(json) {
+//         return new GradingResultDTO(
+//             json.id,
+//             json.gradingCriteriaId,
+//             json.isSatisfied,
+//             json.answerId
+//         );
+//     }
+// }
+
+// // 2. GradingCriteriaDTO
+// class GradingCriteriaDTO {
+//     constructor(id, content, detailContent, scoreWeight) {
+//         this.id = id;
+//         this.content = content;
+//         this.detailContent = detailContent;
+//         this.scoreWeight = scoreWeight;
+//     }
+
+//     static fromJSON(json) {
+//         return new GradingCriteriaDTO(
+//             json.id,
+//             json.content,
+//             json.detailContent,
+//             json.scoreWeight
+//         );
+//     }
+// }
+
+// 3. QuestionOptionDTO
+class QuestionOptionDTO {
+    constructor(id, optionNumber, content) {
+        this.id = id;
+        this.optionNumber = optionNumber;
+        this.content = content;
+    }
+
+    static fromJSON(json) {
+        return new QuestionOptionDTO(
+            json.id,
+            json.optionNumber,
+            json.content
+        );
+    }
+}
+
+// 4. QuestionQueryDTO
+class QuestionQueryDTO {
+    constructor({
+        id, content, detailContent, type, difficulty, answer,
+        createdMemberId, createdMemberName, updatedMemberId, updatedMemberName,
+        createdAt, updatedAt, options, usedJobTests
+        // , gradingCriteria
+    }) {
+        this.id = id;
+        this.content = content;
+        this.detailContent = detailContent;
+        this.type = type;
+        this.difficulty = difficulty;
+        this.answer = answer;
+        this.createdMemberId = createdMemberId;
+        this.createdMemberName = createdMemberName;
+        this.updatedMemberId = updatedMemberId;
+        this.updatedMemberName = updatedMemberName;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.options = (options || []).map(QuestionOptionDTO.fromJSON);
+        this.usedJobTests = usedJobTests || [];
+        // this.gradingCriteria = (gradingCriteria || []).map(GradingCriteriaDTO.fromJSON);
+    }
+
+    static fromJSON(json) {
+        return new QuestionQueryDTO(json);
+    }
+}
+
+// 5. AnswerQueryDTO (루트)
+class AnswerQueryDTO {
+    constructor({
+        id, content, attempt, isCorrect, score, applicationJobTestId, questionId,
+        question
+        // , gradingResults
+    }) {
+        this.id = id;
+        this.content = content;
+        this.attempt = attempt;
+        this.isCorrect = isCorrect;
+        this.score = score;
+        this.applicationJobTestId = applicationJobTestId;
+        this.questionId = questionId;
+        this.question = question ? QuestionQueryDTO.fromJSON(question) : null;
+        // this.gradingResults = (gradingResults || []).map(GradingResultDTO.fromJSON);
+    }
+
+    static fromJSON(json) {
+        return new AnswerQueryDTO(json);
+    }
+}
+
+// ----- export -----
+export {
+    AnswerQueryDTO,
+    QuestionQueryDTO,
+    QuestionOptionDTO,
+    // GradingCriteriaDTO,
+    // GradingResultDTO
+};
+// 또는 default export도 필요하다면:
+export default AnswerQueryDTO;

--- a/src/dto/employment/jobtest/answerResponseDTO.js
+++ b/src/dto/employment/jobtest/answerResponseDTO.js
@@ -89,7 +89,7 @@ class QuestionQueryDTO {
 class AnswerQueryDTO {
     constructor({
         id, content, attempt, isCorrect, score, applicationJobTestId, questionId,
-        question
+        question, maxScore
         // , gradingResults
     }) {
         this.id = id;
@@ -97,6 +97,7 @@ class AnswerQueryDTO {
         this.attempt = attempt;
         this.isCorrect = isCorrect;
         this.score = score;
+        this.maxScore = maxScore;
         this.applicationJobTestId = applicationJobTestId;
         this.questionId = questionId;
         this.question = question ? QuestionQueryDTO.fromJSON(question) : null;

--- a/src/dto/employment/jobtest/questionDetailResponseDTO.js
+++ b/src/dto/employment/jobtest/questionDetailResponseDTO.js
@@ -1,0 +1,118 @@
+// 문제 선지 DTO
+export class QuestionOptionDTO {
+    constructor(optionNumber, content) {
+        this.optionNumber = optionNumber;
+        this.content = content;
+    }
+    static fromJSON(json) {
+        return new QuestionOptionDTO(json.optionNumber, json.content);
+    }
+    toJSON() {
+        return { optionNumber: this.optionNumber, content: this.content };
+    }
+}
+
+// 사용중인 실무테스트 DTO
+export class UsedJobtestDTO {
+    constructor(id, title) {
+        this.id = id;
+        this.title = title;
+    }
+    static fromJSON(json) {
+        return new UsedJobtestDTO(json.id, json.title);
+    }
+    toJSON() {
+        return { id: this.id, title: this.title };
+    }
+}
+
+// 채점기준 DTO
+// export class GradingCriteriaQueryDTO {
+//     constructor(content, scoreWeight) {
+//         this.content = content;
+//         this.scoreWeight = scoreWeight;
+//     }
+//     static fromJSON(json) {
+//         return new GradingCriteriaQueryDTO(json.content, json.scoreWeight);
+//     }
+//     toJSON() {
+//         return { content: this.content, scoreWeight: this.scoreWeight };
+//     }
+// }
+
+
+export default class QuestionQueryDTO {
+    constructor({
+        id,
+        content,
+        detailContent,
+        type,
+        difficulty,
+        answer,
+        createdMemberId,
+        createdMemberName,
+        updatedMemberId,
+        updatedMemberName,
+        createdAt,
+        updatedAt,
+        options,
+        usedJobTests,
+        // gradingCriteria
+    }) {
+        this.id = id;
+        this.content = content;
+        this.detailContent = detailContent;
+        this.type = type;
+        this.difficulty = difficulty;
+        this.answer = answer;
+        this.createdMemberId = createdMemberId;
+        this.createdMemberName = createdMemberName;
+        this.updatedMemberId = updatedMemberId;
+        this.updatedMemberName = updatedMemberName;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.options = options || [];
+        this.usedJobTests = usedJobTests || [];
+        // this.gradingCriteria = gradingCriteria || [];
+    }
+
+    static fromJSON(json) {
+        return new QuestionQueryDTO({
+            id: json.id,
+            content: json.content,
+            detailContent: json.detailContent,
+            type: json.type,
+            difficulty: json.difficulty,
+            answer: json.answer,
+            createdMemberId: json.createdMemberId,
+            createdMemberName: json.createdMemberName,
+            updatedMemberId: json.updatedMemberId,
+            updatedMemberName: json.updatedMemberName,
+            createdAt: json.createdAt,
+            updatedAt: json.updatedAt,
+            options: json.options ? json.options.map(QuestionOptionDTO.fromJSON) : [],
+            usedJobTests: json.usedJobTests ? json.usedJobTests.map(UsedJobtestDTO.fromJSON) : [],
+            // gradingCriteria: json.gradingCriteria ? json.gradingCriteria.map(GradingCriteriaQueryDTO.fromJSON) : []
+        });
+    }
+
+    toJSON() {
+        return {
+            id: this.id,
+            content: this.content,
+            detailContent: this.detailContent,
+            type: this.type,
+            difficulty: this.difficulty,
+            answer: this.answer,
+            createdMemberId: this.createdMemberId,
+            createdMemberName: this.createdMemberName,
+            updatedMemberId: this.updatedMemberId,
+            updatedMemberName: this.updatedMemberName,
+            createdAt: this.createdAt,
+            updatedAt: this.updatedAt,
+            options: this.options.map(o => o.toJSON()),
+            usedJobTests: this.usedJobTests.map(u => u.toJSON())
+            // gradingCriteria: this.gradingCriteria.map(g => g.toJSON())
+        };
+    }
+}

--- a/src/router/employment.routes.js
+++ b/src/router/employment.routes.js
@@ -59,7 +59,7 @@ export const employmentRoutes = [
     },
     // 실무테스트 답안 상세 조회 페이지
     {
-        path: '/employment/jobtest-answers/:answerId',
+        path: '/employment/jobtest-answers/:applicationJobtestId',
         name: 'JobtestAnswerDetail',
         component: () => import('@/views/employment/JobtestAnswerDetailPage.vue'),
         props: true,

--- a/src/services/answerService.js
+++ b/src/services/answerService.js
@@ -3,23 +3,23 @@ import { JobtestAPI } from '@/apis/routes/jobtest';
 import ApiResponseDTO from '@/dto/common/apiResponseDTO';
 import { withErrorHandling, throwCustomApiError } from '@/utils/errorHandler';
 
-import { AnswerResponseDTO } from '@/dto/employment/jobtest/answerResponseDTO';
+import  AnswerResponseDTO  from '@/dto/employment/jobtest/answerResponseDTO';
 
 /* 지원서별 답안 상세 조회 */
 export const getAnswersByApplicationJobtestId = async (applicationJobtestId, options = {}) => {
     return withErrorHandling(async () => {
-        const response = await api.get(JobtestAPI.ANSWER_DETAIL, applicationJobtestId);
+        const response = await api.get(JobtestAPI.ANSWER_DETAIL(applicationJobtestId));
+
         const apiResponse = ApiResponseDTO.fromJSON(response.data);
 
         if (!apiResponse.success) {
             throwCustomApiError(apiResponse.code, apiResponse.message, 400);
         }
 
-        // 여러 답변일 수도, 단일 답변일 수도 있음
         if (Array.isArray(apiResponse.data)) {
-            return apiResponse.data.map(item => AnswerQueryDTO.fromJSON(item));
+            return apiResponse.data.map(item => AnswerResponseDTO.fromJSON(item));
         } else {
-            return AnswerQueryDTO.fromJSON(apiResponse.data);
+            return AnswerResponseDTO.fromJSON(apiResponse.data);
         }
     }, options);
 };

--- a/src/services/answerService.js
+++ b/src/services/answerService.js
@@ -1,0 +1,25 @@
+import api from '@/apis/apiClient';
+import { JobtestAPI } from '@/apis/routes/jobtest';
+import ApiResponseDTO from '@/dto/common/apiResponseDTO';
+import { withErrorHandling, throwCustomApiError } from '@/utils/errorHandler';
+
+import { AnswerResponseDTO } from '@/dto/employment/jobtest/answerResponseDTO';
+
+/* 지원서별 답안 상세 조회 */
+export const getAnswersByApplicationJobtestId = async (applicationJobtestId, options = {}) => {
+    return withErrorHandling(async () => {
+        const response = await api.get(JobtestAPI.ANSWER_DETAIL, applicationJobtestId);
+        const apiResponse = ApiResponseDTO.fromJSON(response.data);
+
+        if (!apiResponse.success) {
+            throwCustomApiError(apiResponse.code, apiResponse.message, 400);
+        }
+
+        // 여러 답변일 수도, 단일 답변일 수도 있음
+        if (Array.isArray(apiResponse.data)) {
+            return apiResponse.data.map(item => AnswerQueryDTO.fromJSON(item));
+        } else {
+            return AnswerQueryDTO.fromJSON(apiResponse.data);
+        }
+    }, options);
+};

--- a/src/services/jobtestQuestionService.js
+++ b/src/services/jobtestQuestionService.js
@@ -4,6 +4,7 @@ import ApiResponseDTO from '@/dto/common/apiResponseDTO';
 import { withErrorHandling, throwCustomApiError } from '@/utils/errorHandler';
 
 import QuestionResponseDTO from '@/dto/employment/jobtest/questionResponseDTO';
+import QuestionDetailResponseDTO from '@/dto/employment/jobtest/questionDetailResponseDTO';
 
 /**
  * 실무테스트 문제 목록을 조회하는 서비스
@@ -21,6 +22,20 @@ export const getQuestionsService = async (options = {}) => {
         return apiResponse.data.map(item => QuestionResponseDTO.fromJSON(item));
     }, options);
 };
+
+// 실무테스트 문제 상세 조회 서비스
+export const getQuestionDetailService = async (options = {}) => {
+    return withErrorHandling(async () => {
+        const response = await api.get(JobtestAPI.QUESTION_DETAIL);
+        const apiResponse = ApiResponseDTO.fromJSON(response.data);
+
+        if (!apiResponse.success) {
+            throwCustomApiError(apiResponse.code, apiResponse.message, 400);
+        }
+
+        return apiResponse.data.map(item => QuestionDetailResponseDTO.fromJSON(item));
+    }, options);
+}
 
 // 실무테스트 문제 등록 서비스
 export const createQuestionService = async (

--- a/src/stores/answerStore.js
+++ b/src/stores/answerStore.js
@@ -1,0 +1,26 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+import { getAnswersByApplicationJobtestId } from '@/services/answerService';
+
+export const useAnswerStore = defineStore('answer', () => {
+    const answers = ref([]);
+    const loading = ref(false);
+    const error = ref(null);
+
+    const fetchAnswers = async (applicationJobtestId) => {
+        loading.value = true;
+        error.value = null;
+        try {
+            const data = await getAnswersByApplicationJobtestId(applicationJobtestId);
+            answers.value = data;
+        } catch (err) {
+            error.value = err.message || '답변 불러오기 실패';
+        } finally {
+            loading.value = false;
+        }
+    };
+
+    return {
+        answers, loading, error, fetchAnswers
+    };
+});

--- a/src/views/employment/JobtestAnswerDetailPage.vue
+++ b/src/views/employment/JobtestAnswerDetailPage.vue
@@ -1,56 +1,81 @@
 <template>
   <v-container>
-    <h2 class="text-h6 font-weight-bold mb-4">객관식/단답형 답안 목록</h2>
+    <v-row>
+      <v-col cols="4">
+        <h2 class="text-h6 font-weight-bold mb-4">객관식/단답형 답안 목록</h2>
+      </v-col>
+      <v-spacer />
+      <v-col cols="2">
+        <div class="mb-6">
+          <span class="font-weight-bold text-lg">총점:</span>
+          <span class="ml-2 text-xl" style="color: #388e3c;">{{ totalScore }}점</span>
+        </div>
+      </v-col>
+    </v-row>
     <v-row dense>
-      <v-col
-        v-for="answer in filteredAnswers"
-        :key="answer.id"
-        cols="12"
-        md="6"
-      >
-        <v-card class="mb-4">
-          <v-card-title>
-            <span class="font-weight-bold">문제:</span>
-            <span class="ml-2">{{ answer.question.content }}</span>
+      <v-col v-for="(answer, idx) in filteredAnswers" :key="answer.id" cols="12" md="12">
+        <v-card class="mb-6" :class="{
+          'bg-red-lighten-5': answer.isCorrect === 'WRONG',
+          'bg-green-lighten-5': answer.isCorrect === 'CORRECT'
+        }">
+          <v-card-title class="d-flex justify-space-between align-center pb-0">
+            <span class="font-weight-bold">{{ idx + 1 }}. {{ answer.question.content }}</span>
+            <span class="display-1" :class="{
+              'text-grey': answer.isCorrect === 'WRONG',
+              'text-success': answer.isCorrect === 'CORRECT'
+            }">
+              {{ answer.score }}/{{ answer.maxScore || 3 }}
+            </span>
           </v-card-title>
+
           <v-card-text>
-            <!-- 선택지가 있는 경우 -->
-            <div v-if="hasOptions(answer)">
-              <div class="mb-2 font-weight-bold">선택지</div>
-              <v-list dense>
-                <v-list-item
-                  v-for="opt in answer.question.options"
-                  :key="opt.id"
-                  :class="{
-                    'bg-green-lighten-4': isCorrectOption(answer, opt),
-                    'bg-grey-lighten-3': isSelectedOption(answer, opt) && !isCorrectOption(answer, opt)
-                  }"
-                >
-                  <v-list-item-content>
-                    <v-list-item-title>
-                      {{ opt.optionNumber }}. {{ opt.content }}
-                      <v-chip v-if="isCorrectOption(answer, opt)" color="success" size="x-small" class="ml-2">정답</v-chip>
-                      <v-chip v-else-if="isSelectedOption(answer, opt)" color="primary" size="x-small" class="ml-2">선택</v-chip>
-                    </v-list-item-title>
-                  </v-list-item-content>
-                </v-list-item>
-              </v-list>
-            </div>
-            <!-- 선택지가 없는 경우: 주관식 -->
-            <div v-else>
-              <span class="font-weight-bold">정답:</span>
-              <span class="ml-2">{{ answer.question.answer }}</span> <br>
-              <span class="font-weight-bold">답변:</span>
-              <span class="ml-2">{{ answer.content }}</span>
-            </div>
+            <!-- 선택지가 있는 경우: 객관식 -->
+            <template v-if="hasOptions(answer)">
+              <div class="mb-3">
+                <div v-for="opt in answer.question.options" :key="opt.id" class="mb-1" :style="{
+                  color: isSelectedOption(answer, opt) ? '#222' : '#bbb',
+                  fontWeight: isSelectedOption(answer, opt) ? 'bold' : 'normal',
+                  fontSize: isSelectedOption(answer, opt) ? '1.1em' : '1em'
+                }">
+                  {{ opt.optionNumber }}. {{ opt.content }}
+                  <v-chip v-if="isCorrectOption(answer, opt)" color="success" size="x-small" class="ml-2">정답</v-chip>
+                  <v-chip v-else-if="isSelectedOption(answer, opt)" color="primary" size="x-small"
+                    class="ml-2">선택</v-chip>
+                </div>
+              </div>
+              <v-divider class="my-6" />
+              <!-- 오답일 때 정답 강조 -->
+              <div v-if="answer.isCorrect === 'WRONG'" class="mt-6">
+                <span class="font-weight-bold">정답 :</span>
+                <span class="text-error font-weight-bold text-lg ml-2">
+                  {{ getAnswerContent(answer.question) }}
+                </span>
+              </div>
+            </template>
+
+            <!-- 선택지 없는 경우: 주관식 -->
+            <template v-else>
+              <div class="mb-2">
+                <span class="font-weight-bold">정답:</span>
+                <span class="ml-2">{{ answer.question.answer }}</span>
+              </div>
+              <div>
+                <span class="font-weight-bold">답변:</span>
+                <span class="ml-2">{{ answer.content }}</span>
+              </div>
+            </template>
+
             <!-- 공통 정보 -->
-            <div class="mt-3">
-              <span class="font-weight-bold">채점 결과:</span>
-              <v-chip :color="getColor(answer.isCorrect)" class="ml-2" size="small">
-                {{ getResultLabel(answer.isCorrect) }}
-              </v-chip>
-              <span class="ml-4">점수: <strong>{{ answer.score }}</strong></span>
-              <span class="ml-4">시도: <strong>{{ answer.attempt }}</strong>회</span>
+            <div class="mt-3 d-flex align-center justify-space-between">
+              <div>
+                <span class="font-weight-bold">채점 결과:</span>
+                <v-chip :color="getColor(answer.isCorrect)" class="ml-2" size="small">
+                  {{ getResultLabel(answer.isCorrect) }}
+                </v-chip>
+                <span class="ml-4">점수: <strong>{{ answer.score }}</strong></span>
+                <span class="ml-4">시도: <strong>{{ answer.attempt }}</strong>회</span>
+              </div>
+              <!-- <v-btn color="success" variant="tonal" size="large">정정하기</v-btn> -->
             </div>
           </v-card-text>
         </v-card>
@@ -59,49 +84,56 @@
   </v-container>
 </template>
 
-
 <script setup>
 import { computed, onMounted } from 'vue';
-import  AnswerResponseDTO  from '@/dto/employment/jobtest/answerResponseDTO';
+import AnswerResponseDTO from '@/dto/employment/jobtest/answerResponseDTO';
 import { useAnswerStore } from '@/stores/answerStore';
 
 const props = defineProps(['applicationJobtestId']);
-// 1. Pinia에서 가져오기
 const answerStore = useAnswerStore();
 
-// 2. DTO 변환 (만약 아직 변환 전 원본 JSON 상태라면)
 const answers = computed(() =>
   answerStore.answers.map(AnswerResponseDTO.fromJSON)
 );
 
-// 3. DESCRIPTIVE 아닌 것만
+// DESCRIPTIVE가 아닌 것만
 const filteredAnswers = computed(() =>
   answers.value.filter(a => a.question.type !== 'DESCRIPTIVE')
 );
 
-console.log(filteredAnswers.value);
+const totalScore = computed(() =>
+  filteredAnswers.value.reduce((sum, a) => sum + (a.score || 0), 0)
+);
 
-// 선택지가 있는지 체크
 function hasOptions(answer) {
   return answer.question.options && answer.question.options.length > 0;
 }
 
-// 내 답변(숫자 또는 문자열) == 옵션번호 or 옵션 내용 일치 여부
 function isSelectedOption(answer, option) {
-  // 답변이 옵션 번호(숫자)로 제출되었는지, 옵션 내용(문자)인지 상황에 맞게 비교
-  // 예: answer.content === "2" 또는 answer.content === "의존성 명확화"
   return (
     answer.content == option.optionNumber ||
     answer.content === option.content
   );
 }
 
-// 정답 옵션
 function isCorrectOption(answer, option) {
   return (
     answer.question.answer == option.optionNumber ||
     answer.question.answer === option.content
   );
+}
+
+// 정답 옵션을 옵션번호가 아닌 옵션 내용으로 변환
+function getAnswerContent(question) {
+  if (question.options && question.options.length) {
+    const found = question.options.find(
+      (opt) =>
+        question.answer == opt.optionNumber ||
+        question.answer === opt.content
+    );
+    return found ? `${found.optionNumber}. ${found.content}` : question.answer;
+  }
+  return question.answer;
 }
 
 function getColor(status) {
@@ -130,10 +162,10 @@ function getResultLabel(status) {
 }
 
 onMounted(async () => {
-    try {
-        await answerStore.fetchAnswers(Number(props.applicationJobtestId));
-    } catch (error) {
-        console.error('Failed to fetch answer:', error)
-    }
-})
+  try {
+    await answerStore.fetchAnswers(Number(props.applicationJobtestId));
+  } catch (error) {
+    console.error('Failed to fetch answer:', error);
+  }
+});
 </script>

--- a/src/views/employment/JobtestAnswerDetailPage.vue
+++ b/src/views/employment/JobtestAnswerDetailPage.vue
@@ -38,6 +38,8 @@
             </div>
             <!-- 선택지가 없는 경우: 주관식 -->
             <div v-else>
+              <span class="font-weight-bold">정답:</span>
+              <span class="ml-2">{{ answer.question.answer }}</span> <br>
               <span class="font-weight-bold">답변:</span>
               <span class="ml-2">{{ answer.content }}</span>
             </div>
@@ -59,80 +61,25 @@
 
 
 <script setup>
-import { computed } from 'vue';
+import { computed, onMounted } from 'vue';
 import  AnswerResponseDTO  from '@/dto/employment/jobtest/answerResponseDTO';
+import { useAnswerStore } from '@/stores/answerStore';
 
-const rawData = [
-  {
-    "id": 5,
-    "content": "함수",
-    "attempt": 3,
-    "isCorrect": "CORRECT",
-    "score": 20,
-    "applicationJobTestId": 5,
-    "questionId": 5,
-    "question": {
-      "id": 5,
-      "content": "반복문과 조건문의 차이점 중 옳은 것은?",
-      "detailContent": "",
-      "type": "SUBJECTIVE",
-      "difficulty": "MEDIUM",
-      "answer": "함수"
-    }
-  },
-  {
-    "id": 11,
-    "content": 3,
-    "attempt": 3,
-    "isCorrect": "CORRECT",
-    "score": 10,
-    "applicationJobTestId": 5,
-    "questionId": 1,
-    "question": {
-      "id": 1,
-      "content": "가상 DOM과 가장 DOM 중 옳은 것은?",
-      "detailContent": "",
-      "type": "SUBJECTIVE",
-      "difficulty": "MEDIUM",
-      "answer": "가상 DOM",
-      "options": [
-        { "id": 1, "optionNumber": 1, "content": "빠른 렌더링" },
-        { "id": 2, "optionNumber": 2, "content": "양방향 바인딩" },
-        { "id": 3, "optionNumber": 3, "content": "가상 DOM" },
-        { "id": 4, "optionNumber": 4, "content": "템플릿 기반" }
-      ]
-    }
-  },
-  {
-    "id": 12,
-    "content": "4",
-    "attempt": 1,
-    "isCorrect": "WRONG",
-    "score": 0,
-    "applicationJobTestId": 5,
-    "questionId": 2,
-    "question": {
-      "id": 2,
-      "content": "Spring Boot에서 DI가 중요한 이유는?",
-      "detailContent": "",
-      "type": "SUBJECTIVE",
-      "difficulty": "EASY",
-      "answer": "의존성 명확화",
-      "options": [
-        { "id": 5, "optionNumber": 1, "content": "결합도 증가" },
-        { "id": 6, "optionNumber": 2, "content": "의존성 명확화" },
-        { "id": 7, "optionNumber": 3, "content": "애노테이션 미사용" },
-        { "id": 8, "optionNumber": 4, "content": "테스트 어려움" }
-      ]
-    }
-  }
-  // ... (DESCRIPTIVE 문제 제외)
-];
+const props = defineProps(['applicationJobtestId']);
+// 1. Pinia에서 가져오기
+const answerStore = useAnswerStore();
 
-// DESCRIPTIVE가 아닌 것만
-const filteredAnswers = computed(() =>
-  rawData.filter(a => a.question.type !== 'DESCRIPTIVE')
+// 2. DTO 변환 (만약 아직 변환 전 원본 JSON 상태라면)
+const answers = computed(() =>
+  answerStore.answers.map(AnswerResponseDTO.fromJSON)
 );
+
+// 3. DESCRIPTIVE 아닌 것만
+const filteredAnswers = computed(() =>
+  answers.value.filter(a => a.question.type !== 'DESCRIPTIVE')
+);
+
+console.log(filteredAnswers.value);
 
 // 선택지가 있는지 체크
 function hasOptions(answer) {
@@ -181,4 +128,12 @@ function getResultLabel(status) {
       return '미채점';
   }
 }
+
+onMounted(async () => {
+    try {
+        await answerStore.fetchAnswers(Number(props.applicationJobtestId));
+    } catch (error) {
+        console.error('Failed to fetch answer:', error)
+    }
+})
 </script>

--- a/src/views/employment/JobtestAnswerDetailPage.vue
+++ b/src/views/employment/JobtestAnswerDetailPage.vue
@@ -1,11 +1,184 @@
 <template>
-    <div>
-
-    </div>
+  <v-container>
+    <h2 class="text-h6 font-weight-bold mb-4">객관식/단답형 답안 목록</h2>
+    <v-row dense>
+      <v-col
+        v-for="answer in filteredAnswers"
+        :key="answer.id"
+        cols="12"
+        md="6"
+      >
+        <v-card class="mb-4">
+          <v-card-title>
+            <span class="font-weight-bold">문제:</span>
+            <span class="ml-2">{{ answer.question.content }}</span>
+          </v-card-title>
+          <v-card-text>
+            <!-- 선택지가 있는 경우 -->
+            <div v-if="hasOptions(answer)">
+              <div class="mb-2 font-weight-bold">선택지</div>
+              <v-list dense>
+                <v-list-item
+                  v-for="opt in answer.question.options"
+                  :key="opt.id"
+                  :class="{
+                    'bg-green-lighten-4': isCorrectOption(answer, opt),
+                    'bg-grey-lighten-3': isSelectedOption(answer, opt) && !isCorrectOption(answer, opt)
+                  }"
+                >
+                  <v-list-item-content>
+                    <v-list-item-title>
+                      {{ opt.optionNumber }}. {{ opt.content }}
+                      <v-chip v-if="isCorrectOption(answer, opt)" color="success" size="x-small" class="ml-2">정답</v-chip>
+                      <v-chip v-else-if="isSelectedOption(answer, opt)" color="primary" size="x-small" class="ml-2">선택</v-chip>
+                    </v-list-item-title>
+                  </v-list-item-content>
+                </v-list-item>
+              </v-list>
+            </div>
+            <!-- 선택지가 없는 경우: 주관식 -->
+            <div v-else>
+              <span class="font-weight-bold">답변:</span>
+              <span class="ml-2">{{ answer.content }}</span>
+            </div>
+            <!-- 공통 정보 -->
+            <div class="mt-3">
+              <span class="font-weight-bold">채점 결과:</span>
+              <v-chip :color="getColor(answer.isCorrect)" class="ml-2" size="small">
+                {{ getResultLabel(answer.isCorrect) }}
+              </v-chip>
+              <span class="ml-4">점수: <strong>{{ answer.score }}</strong></span>
+              <span class="ml-4">시도: <strong>{{ answer.attempt }}</strong>회</span>
+            </div>
+          </v-card-text>
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
+
 <script setup>
+import { computed } from 'vue';
+import  AnswerResponseDTO  from '@/dto/employment/jobtest/answerResponseDTO';
 
+const rawData = [
+  {
+    "id": 5,
+    "content": "함수",
+    "attempt": 3,
+    "isCorrect": "CORRECT",
+    "score": 20,
+    "applicationJobTestId": 5,
+    "questionId": 5,
+    "question": {
+      "id": 5,
+      "content": "반복문과 조건문의 차이점 중 옳은 것은?",
+      "detailContent": "",
+      "type": "SUBJECTIVE",
+      "difficulty": "MEDIUM",
+      "answer": "함수"
+    }
+  },
+  {
+    "id": 11,
+    "content": 3,
+    "attempt": 3,
+    "isCorrect": "CORRECT",
+    "score": 10,
+    "applicationJobTestId": 5,
+    "questionId": 1,
+    "question": {
+      "id": 1,
+      "content": "가상 DOM과 가장 DOM 중 옳은 것은?",
+      "detailContent": "",
+      "type": "SUBJECTIVE",
+      "difficulty": "MEDIUM",
+      "answer": "가상 DOM",
+      "options": [
+        { "id": 1, "optionNumber": 1, "content": "빠른 렌더링" },
+        { "id": 2, "optionNumber": 2, "content": "양방향 바인딩" },
+        { "id": 3, "optionNumber": 3, "content": "가상 DOM" },
+        { "id": 4, "optionNumber": 4, "content": "템플릿 기반" }
+      ]
+    }
+  },
+  {
+    "id": 12,
+    "content": "4",
+    "attempt": 1,
+    "isCorrect": "WRONG",
+    "score": 0,
+    "applicationJobTestId": 5,
+    "questionId": 2,
+    "question": {
+      "id": 2,
+      "content": "Spring Boot에서 DI가 중요한 이유는?",
+      "detailContent": "",
+      "type": "SUBJECTIVE",
+      "difficulty": "EASY",
+      "answer": "의존성 명확화",
+      "options": [
+        { "id": 5, "optionNumber": 1, "content": "결합도 증가" },
+        { "id": 6, "optionNumber": 2, "content": "의존성 명확화" },
+        { "id": 7, "optionNumber": 3, "content": "애노테이션 미사용" },
+        { "id": 8, "optionNumber": 4, "content": "테스트 어려움" }
+      ]
+    }
+  }
+  // ... (DESCRIPTIVE 문제 제외)
+];
+
+// DESCRIPTIVE가 아닌 것만
+const filteredAnswers = computed(() =>
+  rawData.filter(a => a.question.type !== 'DESCRIPTIVE')
+);
+
+// 선택지가 있는지 체크
+function hasOptions(answer) {
+  return answer.question.options && answer.question.options.length > 0;
+}
+
+// 내 답변(숫자 또는 문자열) == 옵션번호 or 옵션 내용 일치 여부
+function isSelectedOption(answer, option) {
+  // 답변이 옵션 번호(숫자)로 제출되었는지, 옵션 내용(문자)인지 상황에 맞게 비교
+  // 예: answer.content === "2" 또는 answer.content === "의존성 명확화"
+  return (
+    answer.content == option.optionNumber ||
+    answer.content === option.content
+  );
+}
+
+// 정답 옵션
+function isCorrectOption(answer, option) {
+  return (
+    answer.question.answer == option.optionNumber ||
+    answer.question.answer === option.content
+  );
+}
+
+function getColor(status) {
+  switch (status) {
+    case 'CORRECT':
+      return 'success';
+    case 'PARTIAL':
+      return 'warning';
+    case 'WRONG':
+      return 'error';
+    default:
+      return 'default';
+  }
+}
+function getResultLabel(status) {
+  switch (status) {
+    case 'CORRECT':
+      return '정답';
+    case 'PARTIAL':
+      return '부분정답';
+    case 'WRONG':
+      return '오답';
+    default:
+      return '미채점';
+  }
+}
 </script>
-
-<style scoped></style>


### PR DESCRIPTION
### 🪄 PR 타입

- [X] 신규 기능
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] 버그 픽스

### #️⃣ 연관된 이슈

close #이슈번호

### 📝 변경 사항
- 문제 상세 조회 페이지 구현

### 💭 참고 사항

현재 DB에 값이 뒤죽박죽으로 들어가있어서 실제 답과 제출 답안의 정답 유무에 상관없이 채점 여부가 되어있습니다. 참고해주세요~
https://github.com/Pive-Guyz/be14-fin-Empick-BE/pull/258 
PR이 머지되거나 브랜치 feature/sh/answer_query 를 체크아웃해야 정상 작동합니다!

---

### 📷 관련 스크린샷
![{F2E08E2B-699C-4198-B8F8-78B14C73C2D8}](https://github.com/user-attachments/assets/a47add23-e29c-4c2d-8df4-6b4d8603843e)

### 🧪 테스트 계획 또는 완료 사항

- [x] [실무테스트 제출 답안 조회 페이지](http://localhost:8080/employment/jobtest-answers/2000)
