### PR TITLE
[feat] 실무테스트 상세 조회 페이지 구현

### DIFF
--- a/src/apis/routes/jobtest.js
+++ b/src/apis/routes/jobtest.js
@@ -9,7 +9,7 @@ export const JobtestAPI = {
 
     // 실무테스트
     JOBTESTS: '/api/v1/employment/jobtests',
-    JOBTEST_DETAIL: (id) => `/api/v1/employment/jobtests/${id}`,
+    JOBTEST_DETAIL: (jobtestId) => `/api/v1/employment/jobtests/${jobtestId}`,
 
     // 실무테스트별 문제
     JOBTEST_QUESTIONS: '/api/v1/employment/jobtest-questions',

--- a/src/components/common/ListView.vue
+++ b/src/components/common/ListView.vue
@@ -12,7 +12,7 @@
                 </tr>
             </thead>
             <tbody>
-                <tr v-for="(item, index) in data" :key="index">
+                <tr v-for="(item, index) in data" :key="index" @click="$emit('item-click', item)" style="cursor: pointer;">
                     <td v-if="showCheckbox">
                         <v-checkbox v-model="item.selected" :ripple="false" hide-details density="compact" />
                     </td>

--- a/src/components/employment/JobtestApplicantTable.vue
+++ b/src/components/employment/JobtestApplicantTable.vue
@@ -1,0 +1,49 @@
+<template>
+    <v-card variant="outlined" class="pa-4 mt-6">
+        <h3 class="text-subtitle-1 font-weight-bold mb-4">지원자 현황</h3>
+
+        <v-table dense>
+            <thead>
+                <tr>
+                    <th>No</th>
+                    <th>지원자</th>
+                    <th>채용 공고</th>
+                    <th>채점 상태</th>
+                    <th>채점 점수</th>
+                    <th>채점자</th>
+                    <th>평가 상태</th>
+                    <th>평가 점수</th>
+                    <th>평가자</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr v-for="(app, index) in applications" :key="app.applicationId">
+                    <td>{{ index + 1 }}</td>
+                    <td>{{ app.applicantName }}</td>
+                    <td>{{ app.recruitmentTitle }}</td>
+                    <td>{{ statusLabel(app.gradingStatus) }}</td>
+                    <td>{{ app.gradingScore ?? '-' }}</td>
+                    <td>{{ app.gradingMemberName ?? '-' }}</td>
+                    <td>{{ statusLabel(app.evaluationStatus) }}</td>
+                    <td>{{ app.evaluationScore ?? '-' }}</td>
+                    <td>{{ app.evaluationMemberName ?? '-' }}</td>
+                </tr>
+            </tbody>
+        </v-table>
+    </v-card>
+</template>
+
+<script setup>
+defineProps({
+    applications: Array
+})
+
+const statusLabel = (status) => {
+    switch (status) {
+        case 'COMPLETED': return '완료'
+        case 'IN_PROGRESS': return '진행중'
+        case 'NOT_STARTED': return '미시작'
+        default: return '-'
+    }
+}
+</script>

--- a/src/components/employment/JobtestApplicantTable.vue
+++ b/src/components/employment/JobtestApplicantTable.vue
@@ -21,10 +21,10 @@
                     <td>{{ index + 1 }}</td>
                     <td>{{ app.applicantName }}</td>
                     <td>{{ app.recruitmentTitle }}</td>
-                    <td>{{ statusLabel(app.gradingStatus) }}</td>
+                    <td>{{ getStatusLabel(app.gradingStatus) }}</td>
                     <td>{{ app.gradingScore ?? '-' }}</td>
                     <td>{{ app.gradingMemberName ?? '-' }}</td>
-                    <td>{{ statusLabel(app.evaluationStatus) }}</td>
+                    <td>{{ getStatusLabel(app.evaluationStatus) }}</td>
                     <td>{{ app.evaluationScore ?? '-' }}</td>
                     <td>{{ app.evaluationMemberName ?? '-' }}</td>
                 </tr>
@@ -34,16 +34,10 @@
 </template>
 
 <script setup>
+import { getStatusLabel } from '@/constants/employment/jobtestStatus';
+
 defineProps({
     applications: Array
 })
 
-const statusLabel = (status) => {
-    switch (status) {
-        case 'COMPLETED': return '완료'
-        case 'IN_PROGRESS': return '진행중'
-        case 'NOT_STARTED': return '미시작'
-        default: return '-'
-    }
-}
 </script>

--- a/src/components/employment/JobtestQuestionList.vue
+++ b/src/components/employment/JobtestQuestionList.vue
@@ -1,0 +1,38 @@
+<template>
+    <v-card variant="outlined" class="pa-4">
+        <h3 class="text-subtitle-1 font-weight-bold mb-4">문제 목록</h3>
+        <v-table dense>
+            <thead>
+                <tr>
+                    <th>번호</th>
+                    <th>내용</th>
+                    <th>배점</th>
+                    <th>난이도</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr v-for="(question, index) in questions" :key="question.id">
+                    <td>{{ index + 1 }}</td>
+                    <td>{{ question.content }}</td>
+                    <td>{{ question.score }}점</td>
+                    <td>{{ difficultyLabel(question.difficulty) }}</td>
+                </tr>
+            </tbody>
+        </v-table>
+    </v-card>
+</template>
+
+<script setup>
+defineProps({
+    questions: Array
+})
+
+const difficultyLabel = (level) => {
+    switch (level) {
+        case 'EASY': return '쉬움'
+        case 'MEDIUM': return '보통'
+        case 'HARD': return '어려움'
+        default: return '알 수 없음'
+    }
+}
+</script>

--- a/src/components/employment/JobtestSummaryCard.vue
+++ b/src/components/employment/JobtestSummaryCard.vue
@@ -1,0 +1,40 @@
+<template>
+    <v-card variant="outlined" class="pa-4 mb-4">
+        <div class="d-flex justify-space-between">
+            <div>
+                <div class="text-h6 font-weight-bold mb-2">{{ jobtest.title }}</div>
+                <div class="text-subtitle-2">난이도: {{ difficultyLabel }}</div>
+                <div class="text-subtitle-2">시험 시간: {{ jobtest.testTime }}분</div>
+                <div class="text-subtitle-2">시작: {{ formatDate(jobtest.startedAt) }}</div>
+                <div class="text-subtitle-2">종료: {{ formatDate(jobtest.endedAt) }}</div>
+            </div>
+            <div class="text-right">
+                <div class="text-subtitle-2">생성자: {{ jobtest.createdName }} ({{ formatDate(jobtest.createdAt) }})</div>
+                <div class="text-subtitle-2">수정자: {{ jobtest.updatedName }} ({{ formatDate(jobtest.updatedAt) }})</div>
+            </div>
+        </div>
+    </v-card>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+    jobtest: Object
+})
+
+const difficultyLabel = computed(() => {
+    switch (props.jobtest.difficulty) {
+        case 'EASY': return '쉬움'
+        case 'MEDIUM': return '보통'
+        case 'HARD': return '어려움'
+        default: return '알 수 없음'
+    }
+})
+
+const formatDate = (dateStr) => {
+    if (!dateStr) return '-'
+    const date = new Date(dateStr)
+    return `${date.toLocaleDateString()} ${date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`
+}
+</script>

--- a/src/constants/employment/jobtestStatus.js
+++ b/src/constants/employment/jobtestStatus.js
@@ -1,0 +1,14 @@
+export const STATUS_LABEL_MAP = {
+  'WAITING': '대기중',
+  'IN_PROGRESS': '진행 중',
+  'COMPLETED': '완료',
+};
+
+/**
+ * 상태 코드 한글화
+ * @param {keyof typeof STATUS_LABEL_MAP} status - 상태 코드
+ * @returns {string} 한글화된 상태
+ */
+export const getStatusLabel = (status) => {
+  return STATUS_LABEL_MAP[status] || status;
+};

--- a/src/dto/employment/jobtest/jobtestDetailDTO.js
+++ b/src/dto/employment/jobtest/jobtestDetailDTO.js
@@ -125,9 +125,9 @@ export default class JobtestDetailDTO {
     static fromJSON(json) {
         return new JobtestDetailDTO({
             ...json,
-            questions: json.questions?.map(JobtestQuestionSummaryDTO.fromJSON) || [],
+            questions: (json.questions || []).filter(q => q.questionId !== 0).map(JobtestQuestionSummaryDTO.fromJSON),
             evaluationCriteria: json.evaluationCriteria?.map(EvaluationCriteriaDTO.fromJSON) || [],
-            applications: json.applications?.map(JobtestApplicationDTO.fromJSON) || []
+            applications: (json.applications || []).filter(a => a.applicationId !== 0 && a.applicantName !== null).map(JobtestApplicationDTO.fromJSON),
         });
     }
 

--- a/src/dto/employment/jobtest/jobtestDetailDTO.js
+++ b/src/dto/employment/jobtest/jobtestDetailDTO.js
@@ -1,0 +1,151 @@
+// 문제 요약 DTO
+export class JobtestQuestionSummaryDTO {
+    constructor(score, optionNumber, questionId, difficulty, content) {
+        this.score = score;
+        this.optionNumber = optionNumber;
+        this.questionId = questionId;
+        this.difficulty = difficulty;
+        this.content = content;
+    }
+
+    static fromJSON(json) {
+        return new JobtestQuestionSummaryDTO(
+            json.score,
+            json.optionNumber,
+            json.questionId,
+            json.difficulty,
+            json.content
+        );
+    }
+
+    toJSON() {
+        return {
+            score: this.score,
+            optionNumber: this.optionNumber,
+            questionId: this.questionId,
+            difficulty: this.difficulty
+        };
+    }
+}
+
+// 평가 기준 DTO
+export class EvaluationCriteriaDTO {
+    constructor(content, detailContent, scoreWeight) {
+        this.content = content;
+        this.detailContent = detailContent;
+        this.scoreWeight = scoreWeight;
+    }
+
+    static fromJSON(json) {
+        return new EvaluationCriteriaDTO(
+            json.content,
+            json.detailContent,
+            json.scoreWeight
+        );
+    }
+
+    toJSON() {
+        return {
+            content: this.content,
+            detailContent: this.detailContent,
+            scoreWeight: this.scoreWeight
+        };
+    }
+}
+
+// 지원자 DTO
+export class JobtestApplicationDTO {
+    constructor({
+        applicationId,
+        applicantId,
+        applicantName,
+        recruitmentTitle,
+        gradingStatus,
+        gradingScore,
+        gradingMemberName,
+        evaluationStatus,
+        evaluationScore,
+        evaluationMemberName,
+        applicationJobtestId
+    }) {
+        this.applicationId = applicationId;
+        this.applicantId = applicantId;
+        this.applicantName = applicantName;
+        this.recruitmentTitle = recruitmentTitle;
+        this.gradingStatus = gradingStatus;
+        this.gradingScore = gradingScore;
+        this.gradingMemberName = gradingMemberName;
+        this.evaluationStatus = evaluationStatus;
+        this.evaluationScore = evaluationScore;
+        this.evaluationMemberName = evaluationMemberName;
+        this.applicationJobtestId = applicationJobtestId;
+    }
+
+    static fromJSON(json) {
+        return new JobtestApplicationDTO(json);
+    }
+
+    toJSON() {
+        return { ...this };
+    }
+}
+
+// 실무 테스트 상세 DTO
+export default class JobtestDetailDTO {
+    constructor({
+        id,
+        title,
+        difficulty,
+        testTime,
+        startedAt,
+        endedAt,
+        createdName,
+        updatedName,
+        createdAt,
+        updatedAt,
+        questions = [],
+        evaluationCriteria = [],
+        applications = []
+    }) {
+        this.id = id;
+        this.title = title;
+        this.difficulty = difficulty;
+        this.testTime = testTime;
+        this.startedAt = startedAt;
+        this.endedAt = endedAt;
+        this.createdName = createdName;
+        this.updatedName = updatedName;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.questions = questions;
+        this.evaluationCriteria = evaluationCriteria;
+        this.applications = applications;
+    }
+
+    static fromJSON(json) {
+        return new JobtestDetailDTO({
+            ...json,
+            questions: json.questions?.map(JobtestQuestionSummaryDTO.fromJSON) || [],
+            evaluationCriteria: json.evaluationCriteria?.map(EvaluationCriteriaDTO.fromJSON) || [],
+            applications: json.applications?.map(JobtestApplicationDTO.fromJSON) || []
+        });
+    }
+
+    toJSON() {
+        return {
+            id: this.id,
+            title: this.title,
+            difficulty: this.difficulty,
+            testTime: this.testTime,
+            startedAt: this.startedAt,
+            endedAt: this.endedAt,
+            createdName: this.createdName,
+            updatedName: this.updatedName,
+            createdAt: this.createdAt,
+            updatedAt: this.updatedAt,
+            questions: this.questions.map(q => q.toJSON()),
+            evaluationCriteria: this.evaluationCriteria.map(c => c.toJSON()),
+            applications: this.applications.map(a => a.toJSON())
+        };
+    }
+}

--- a/src/router/employment.routes.js
+++ b/src/router/employment.routes.js
@@ -36,7 +36,7 @@ export const employmentRoutes = [
     },
     // 실무테스트 상세 조회 페이지
     {
-        path: '/employment/jobtests/:id',
+        path: '/employment/jobtests/:jobtestId',
         name: 'JobtestDetail',
         component: () => import('@/views/employment/JobtestDetailPage.vue'),
         props: true,

--- a/src/services/jobtestService.js
+++ b/src/services/jobtestService.js
@@ -2,10 +2,12 @@ import api from '@/apis/apiClient';
 import { JobtestAPI } from '@/apis/routes/jobtest';
 import { withErrorHandling, throwCustomApiError } from '@/utils/errorHandler';
 import ApiResponseDTO from '@/dto/common/apiResponseDTO';
+
 import JobtestListResponseDTO from '@/dto/employment/jobtest/jobtestListResponseDTO';
+import JobtestDetailDTO from '@/dto/employment/jobtest/jobtestDetailDTO';
 
 // 실무테스트 목록 조회 서비스
-export const getQuestionsService = async (options = {}) => {
+export const getJobtestListService = async (options = {}) => {
     return withErrorHandling(async () => {
         const response = await api.get(JobtestAPI.JOBTESTS);
         const apiResponse = ApiResponseDTO.fromJSON(response.data);
@@ -16,6 +18,21 @@ export const getQuestionsService = async (options = {}) => {
         }
 
         return apiResponse.data.map(item => JobtestListResponseDTO.fromJSON(item));
+    }, options);
+};
+
+// 실무테스트 상세 조회 서비스
+export const getJobtestService = async (jobtestId, options = {}) => {
+    return withErrorHandling(async () => {
+        const response = await api.get(JobtestAPI.JOBTEST_DETAIL(jobtestId));
+        const apiResponse = ApiResponseDTO.fromJSON(response.data);
+
+        console.log('[DEBUG] Jobtest API Response:', apiResponse);
+        if (!apiResponse.success) {
+            throwCustomApiError(apiResponse.code, apiResponse.message, 400);
+        }
+
+        return JobtestDetailDTO.fromJSON(apiResponse.data);
     }, options);
 };
 

--- a/src/stores/jobtestDetailStore.js
+++ b/src/stores/jobtestDetailStore.js
@@ -1,0 +1,31 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+import { getJobtestService } from '@/services/jobtestService'
+import JobtestDetailDTO from '@/dto/employment/jobtest/jobtestDetailDTO';
+
+export const useJobtestDetailStore = defineStore('jobtestDetail', () => {
+    const jobtest = ref(null);
+    const loading = ref(false);
+    const error = ref(null);
+
+    const fetchJobtestDetail = async (jobtestId) => {
+        loading.value = true;
+        error.value = null;
+        try {
+            const response = await getJobtestService(jobtestId);
+            jobtest.value = JobtestDetailDTO.fromJSON(response);
+        } catch (e) {
+            error.value = e.message || '실무테스트 조회 실패';
+            throw e;
+        } finally {
+            loading.value = false;
+        }
+    };
+
+    return {
+        jobtest,
+        loading,
+        error,
+        fetchJobtestDetail
+    };
+});

--- a/src/stores/jobtestListStore.js
+++ b/src/stores/jobtestListStore.js
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia';
 import { ref, computed } from 'vue';
-import { getQuestionsService } from '@/services/jobtestService';
+import { getJobtestListService } from '@/services/jobtestService';
 import { getDifficultyLabel } from '@/constants/employment/difficulty';
 
 export const useJobtestListStore = defineStore('jobtestList', () => {
@@ -15,7 +15,7 @@ export const useJobtestListStore = defineStore('jobtestList', () => {
         loading.value = true;
         error.value = null;
         try {
-            const response = await getQuestionsService(); // ✅ 서비스 사용
+            const response = await getJobtestListService(); // ✅ 서비스 사용
             jobtests.value = response.map(item => ({
                 ...item,
                 difficulty: getDifficultyLabel(item.difficulty)

--- a/src/views/employment/JobtestDetailPage.vue
+++ b/src/views/employment/JobtestDetailPage.vue
@@ -6,6 +6,10 @@
 
     <!-- 로딩 완료 후 jobtest가 있을 때 -->
     <v-container v-else-if="jobtest" fluid>
+        <v-btn prepend-icon="mdi-arrow-left" variant="tonal" class="mb-4" @click="goJobtestList">
+            목록으로
+        </v-btn>
+
         <!-- 요약 카드 -->
         <jobtest-summary-card :jobtest="jobtest" class="mb-6" />
 
@@ -32,7 +36,7 @@
 
 <script setup>
 import { computed, onMounted } from 'vue'
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { useJobtestDetailStore } from '@/stores/jobtestDetailStore'
 
 import JobtestSummaryCard from '@/components/employment/JobtestSummaryCard.vue'
@@ -41,6 +45,7 @@ import JobtestEvaluationCriteria from '@/components/common/EvaluationCriteriaLis
 import JobtestApplicantTable from '@/components/employment/JobtestApplicantTable.vue'
 
 const route = useRoute()
+const router = useRouter()
 const props = defineProps(['jobtestId'])
 
 const jobtestDetailStore = useJobtestDetailStore()
@@ -52,4 +57,8 @@ onMounted(() => {
 const jobtest = computed(() => jobtestDetailStore.jobtest)
 const loading = computed(() => jobtestDetailStore.loading)
 const error = computed(() => jobtestDetailStore.error)
+
+const goJobtestList = () => {
+    router.push({ name: 'JobtestList' });
+}
 </script>

--- a/src/views/employment/JobtestDetailPage.vue
+++ b/src/views/employment/JobtestDetailPage.vue
@@ -1,11 +1,55 @@
 <template>
-    <div>
+    <!-- 로딩 중일 때 -->
+    <v-container v-if="loading" class="d-flex justify-center align-center" style="height: 300px;">
+        <v-progress-circular indeterminate color="primary" size="60" />
+    </v-container>
 
-    </div>
+    <!-- 로딩 완료 후 jobtest가 있을 때 -->
+    <v-container v-else-if="jobtest" fluid>
+        <!-- 요약 카드 -->
+        <jobtest-summary-card :jobtest="jobtest" class="mb-6" />
+
+        <v-row>
+            <v-col cols="6">
+                <jobtest-question-list :questions="jobtest.questions" />
+            </v-col>
+            <!-- <v-col cols="6">
+        <jobtest-evaluation-criteria :criteria="jobtest.evaluationCriteria" />
+      </v-col> -->
+        </v-row>
+
+        <!-- 지원자 테이블 -->
+        <jobtest-applicant-table :applications="jobtest.applications" />
+    </v-container>
+
+    <!-- 에러 발생 시 -->
+    <v-container v-else class="text-center py-10">
+        <v-alert type="error" title="오류 발생">
+            실무 테스트 정보를 불러오는 중 문제가 발생했습니다.
+        </v-alert>
+    </v-container>
 </template>
 
 <script setup>
+import { computed, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
+import { useJobtestDetailStore } from '@/stores/jobtestDetailStore'
 
+import JobtestSummaryCard from '@/components/employment/JobtestSummaryCard.vue'
+import JobtestQuestionList from '@/components/employment/JobtestQuestionList.vue'
+import JobtestEvaluationCriteria from '@/components/common/EvaluationCriteriaList.vue'
+import JobtestApplicantTable from '@/components/employment/JobtestApplicantTable.vue'
+
+const route = useRoute()
+const props = defineProps(['jobtestId'])
+
+const jobtestDetailStore = useJobtestDetailStore()
+
+onMounted(() => {
+    jobtestDetailStore.fetchJobtestDetail(Number(props.jobtestId))
+})
+
+const jobtest = computed(() => jobtestDetailStore.jobtest)
+const loading = computed(() => jobtestDetailStore.loading)
+const error = computed(() => jobtestDetailStore.error)
 </script>
-
-<style scoped></style>

--- a/src/views/employment/JobtestListPage.vue
+++ b/src/views/employment/JobtestListPage.vue
@@ -40,7 +40,7 @@ const headers = [
 ];
 
 const handleItemClick = (item) => {
-    store.toggleSelection(item.id);
+    router.push({ name: 'JobtestDetail', params: { jobtestId: item.id } });
 };
 
 const handleCreate = () => {


### PR DESCRIPTION
### 🪄 PR 타입

- [X] 신규 기능
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] 버그 픽스

### #️⃣ 연관된 이슈

close #이슈번호

### 📝 변경 사항
- 실무테스트 상세 조회 페이지 구현
- ListView item 클릭하면 이벤트 실행되는 기능 추가

---

### 📷 관련 스크린샷
![{F2CC8253-4993-4E7A-B505-AE2419A4DAAD}](https://github.com/user-attachments/assets/f483db8c-874a-4f00-9b69-dd03097180ec)


### 🧪 테스트 계획 또는 완료 사항

- [ ] [실무테스트 1번 조회 페이지](http://localhost:8080/employment/jobtests/1)
