### PR TITLE
[refactor] 채용요청서 직무, 부서 드롭다운 추가/요청서와 채용공고 연동

### DIFF
--- a/src/apis/routes/recruitment.js
+++ b/src/apis/routes/recruitment.js
@@ -3,6 +3,9 @@ export const RecruitmentAPI = {
     REQUEST_LIST: '/api/v1/employment/recruitments/requests',
     REQUEST_DETAIL: (id) => `/api/v1/employment/recruitments/requests/${id}`,
     REQUEST_CREATE: '/api/v1/employment/recruitments/requests',
+    // 직무, 부서 목록
+    JOB_LIST: '/api/v1/jobs',
+    DEPARTMENT_LIST: '/api/v1/departments',
 
     // 채용 공고
     RECRUITMENT_LIST: '/api/v1/employment/recruitments',

--- a/src/dto/employment/recruitment/recruitmentCreateDTO.js
+++ b/src/dto/employment/recruitment/recruitmentCreateDTO.js
@@ -15,8 +15,7 @@ export default class recruitmentCreateDTO {
     ) {
         this.title = title;
         this.content = content;
-
-        // recruitType을 숫자로 안전하게 변환
+        
         this.recruitType = recruitType;
 
         // 빈 문자열이면 null로 처리

--- a/src/services/recruitmentRequestService.js
+++ b/src/services/recruitmentRequestService.js
@@ -45,3 +45,31 @@ export const createRecruitmentRequest = async (payload, options = {}) => {
         return apiResponse.data;
     }, options);
 };
+
+// 직무(포지션) 목록 조회
+export const fetchJobList = async (options = {}) => {
+    return withErrorHandling(async () => {
+        const response = await api.get(API.RECRUITMENT.JOB_LIST);
+        const apiResponse = ApiResponseDTO.fromJSON(response.data);
+
+        if (!apiResponse.success) {
+            throwCustomApiError(apiResponse.code, apiResponse.message, 400);
+        }
+
+        return apiResponse.data;
+    }, options);
+};
+
+// 부서 목록 조회
+export const fetchDepartmentList = async (options = {}) => {
+    return withErrorHandling(async () => {
+        const response = await api.get(API.RECRUITMENT.DEPARTMENT_LIST);
+        const apiResponse = ApiResponseDTO.fromJSON(response.data);
+
+        if (!apiResponse.success) {
+            throwCustomApiError(apiResponse.code, apiResponse.message, 400);
+        }
+
+        return apiResponse.data;
+    }, options);
+};

--- a/src/stores/recruitmentRequestStore.js
+++ b/src/stores/recruitmentRequestStore.js
@@ -1,10 +1,11 @@
-// 📁 src/stores/recruitmentRequestStore.js
 import { defineStore } from 'pinia';
 import { ref } from 'vue';
 import {
     fetchRecruitmentRequestList,
     fetchRecruitmentRequestDetail,
-    createRecruitmentRequest
+    createRecruitmentRequest,
+    fetchJobList,
+    fetchDepartmentList
 } from '@/services/recruitmentRequestService';
 
 export const useRecruitmentRequestStore = defineStore('recruitmentRequest', () => {
@@ -21,6 +22,28 @@ export const useRecruitmentRequestStore = defineStore('recruitmentRequest', () =
     // 요청서 등록 로딩 상태 및 에러 메시지
     const submitting = ref(false);
     const submitError = ref(null);
+
+    // 직무, 부서
+    const jobList = ref([])
+    const departmentList = ref([])
+
+    const loadJobList = async () => {
+        try {
+            const result = await fetchJobList()
+            jobList.value = result
+        } catch (err) {
+            console.error('직무 목록 조회 실패:', err)
+        }
+    }
+
+    const loadDepartmentList = async () => {
+        try {
+            const result = await fetchDepartmentList()
+            departmentList.value = result
+        } catch (err) {
+            console.error('부서 목록 조회 실패:', err)
+        }
+    }
 
     // 목록 불러오기
     const loadRecruitmentRequestList = async () => {
@@ -82,6 +105,12 @@ export const useRecruitmentRequestStore = defineStore('recruitmentRequest', () =
         // 등록 관련
         submitting,
         submitError,
-        submitRecruitmentRequest
+        submitRecruitmentRequest,
+
+        // 직무, 부서
+        jobList,
+        departmentList,
+        loadJobList,
+        loadDepartmentList,
     };
 });

--- a/src/views/employment/ApplicationItemSelectPage.vue
+++ b/src/views/employment/ApplicationItemSelectPage.vue
@@ -97,13 +97,13 @@ const memberStore = useMemberStore()
 
 const categoryList = computed(() => store.applicationItemCategoryList)
 const selectedIds = computed({
-  get: () => store.selectedApplicationItemIds,
-  set: (val) => store.selectedApplicationItemIds = val
+    get: () => store.selectedApplicationItemIds,
+    set: (val) => store.selectedApplicationItemIds = val
 })
 
 const requiredIds = computed({
-  get: () => store.requiredApplicationItemIds,
-  set: (val) => store.requiredApplicationItemIds = val
+    get: () => store.requiredApplicationItemIds,
+    set: (val) => store.requiredApplicationItemIds = val
 })
 const dateValues = ref({})
 const menuStates = ref({})
@@ -182,11 +182,14 @@ const submit = async () => {
 
     const dto = recruitmentCreateDTO.fromForm({
         ...draft,
+        recruitmentRequestId: draft.recruitmentRequestId,
         recruitType: draft.recruitType,
         applicationItems,
         introduceTemplateId: draft.introduceTemplateId || 1,
         memberId: memberStore.form.id
     })
+
+    console.log('📦 전송 DTO:', JSON.stringify(dto, null, 2));
 
     await store.submitRecruitment(dto)
     store.clearDraftRecruitment()

--- a/src/views/employment/RecruitmentCreatePage.vue
+++ b/src/views/employment/RecruitmentCreatePage.vue
@@ -4,7 +4,7 @@
         <v-row justify="space-between" align="center" class="mb-6">
             <h2 class="text-h5 font-weight-bold">채용 공고 작성</h2>
             <div>
-                <v-btn variant="tonal" class="mr-2" @click="$router.back()">취소하기</v-btn>
+                <v-btn variant="tonal" class="mr-2" @click="cancel">취소하기</v-btn>
                 <v-btn color="success" variant="elevated" @click="goToApplicationItem">지원서 항목 선택</v-btn>
             </div>
         </v-row>
@@ -87,6 +87,8 @@
             </v-row>
         </v-form>
     </v-container>
+    <ConfirmModal v-if="showCancelConfirm" message="작성을 취소하시겠습니까?" @confirm="confirmCancel"
+        @cancel="showCancelConfirm = false" />
 </template>
 
 <script setup>
@@ -96,12 +98,14 @@ import { recruitTypeOptions } from '@/constants/employment/recruitTypes'
 import { QuillEditor } from '@vueup/vue-quill'
 import { stepTypeOptions, getStepTypeLabel } from '@/constants/employment/stepType'
 import { useRecruitmentStore } from '@/stores/recruitmentStore'
+import ConfirmModal from '@/components/common/Modal.vue'
 
 const router = useRouter()
 const route = useRoute()
 const store = useRecruitmentStore()
 const isValid = ref(true)
 const formRef = ref()
+const showCancelConfirm = ref(false)
 
 const newStep = ref({
     stepType: '',
@@ -124,6 +128,16 @@ onMounted(() => {
         Object.assign(form.value, store.draftRecruitment)
     }
 })
+
+const cancel = () => {
+    showCancelConfirm.value = true
+}
+
+const confirmCancel = () => {
+    store.clearDraftRecruitment()
+    store.clearDraftApplicationItems()
+    router.push('/employment/recruitments')
+}
 
 const rules = {
     required: v => !!v || '필수 입력 항목입니다.'

--- a/src/views/employment/RecruitmentCreatePage.vue
+++ b/src/views/employment/RecruitmentCreatePage.vue
@@ -9,6 +9,67 @@
             </div>
         </v-row>
 
+        <v-card v-if="requestDetail" class="mb-6 pa-6" elevation="1" color="#f8faf9">
+            <h3 class="text-subtitle-1 font-weight-bold d-flex align-center mb-4">
+                <v-icon class="mr-2" color="success">mdi-clipboard-text</v-icon>
+                채용 요청서 정보
+            </h3>
+
+            <v-row dense>
+                <!-- 포지션 / 부서 -->
+                <v-col cols="12">
+                    <div class="text-caption text-grey">포지션명</div>
+                    <div class="text-body-1 font-weight-medium">{{ requestDetail.jobName }}</div>
+                </v-col>
+                <v-col cols="12">
+                    <div class="text-caption text-grey">부서명</div>
+                    <div class="text-body-1 font-weight-medium">{{ requestDetail.departmentName }}</div>
+                </v-col>
+
+                <!-- 모집 인원 / 고용 형태 -->
+                <v-col cols="12">
+                    <div class="text-caption text-grey">모집 인원</div>
+                    <div class="text-body-1 font-weight-medium">{{ requestDetail.headcount }}명</div>
+                </v-col>
+                <v-col cols="12">
+                    <div class="text-caption text-grey">고용 형태</div>
+                    <div class="text-body-1 font-weight-medium">{{ requestDetail.employmentType }}</div>
+                </v-col>
+
+                <!-- 근무 지역 -->
+                <v-col cols="12">
+                    <div class="text-caption text-grey">근무 지역</div>
+                    <div class="text-body-1 font-weight-medium">{{ requestDetail.workLocation }}</div>
+                </v-col>
+
+                <!-- 주요 업무 -->
+                <v-col cols="12">
+                    <div class="text-caption text-grey">주요 업무</div>
+                    <div class="text-body-1 font-weight-medium" style="white-space: pre-line;">
+                        {{ requestDetail.responsibility }}
+                    </div>
+                </v-col>
+
+                <!-- 자격 요건 -->
+                <v-col cols="12">
+                    <div class="text-caption text-grey">자격 요건</div>
+                    <div class="text-body-1 font-weight-medium" style="white-space: pre-line;">
+                        {{ requestDetail.qualification }}
+                    </div>
+                </v-col>
+
+                <!-- 우대 사항 -->
+                <v-col cols="12">
+                    <div class="text-caption text-grey">우대 사항</div>
+                    <div class="text-body-1 font-weight-medium" style="white-space: pre-line;">
+                        {{ requestDetail.preference }}
+                    </div>
+                </v-col>
+            </v-row>
+        </v-card>
+
+
+
         <!-- 입력 폼 -->
         <v-form ref="formRef" v-model="isValid">
             <v-row dense>
@@ -99,13 +160,18 @@ import { QuillEditor } from '@vueup/vue-quill'
 import { stepTypeOptions, getStepTypeLabel } from '@/constants/employment/stepType'
 import { useRecruitmentStore } from '@/stores/recruitmentStore'
 import ConfirmModal from '@/components/common/Modal.vue'
+import { fetchRecruitmentRequestDetail } from '@/services/recruitmentRequestService'
 
 const router = useRouter()
 const route = useRoute()
+const requestId = route.query.requestId;
+
 const store = useRecruitmentStore()
 const isValid = ref(true)
 const formRef = ref()
 const showCancelConfirm = ref(false)
+
+const requestDetail = ref(null)
 
 const newStep = ref({
     stepType: '',
@@ -120,12 +186,20 @@ const form = ref({
     imageUrl: '',
     startedAt: '',
     endedAt: '',
-    recruitmentProcesses: []
+    recruitmentProcesses: [],
+    recruitmentRequestId: route.query.id || null
 })
 
-onMounted(() => {
+onMounted(async () => {
     if (store.draftRecruitment) {
         Object.assign(form.value, store.draftRecruitment)
+    }
+
+    const requestId = route.query.id
+    console.log('requestId:', requestId) // 1. requestId 값 확인
+    if (requestId) {
+        requestDetail.value = await fetchRecruitmentRequestDetail(requestId)
+        console.log('requestDetail:', requestDetail.value) // 2. 데이터 도착 확인
     }
 })
 

--- a/src/views/employment/RecruitmentCreatePage.vue
+++ b/src/views/employment/RecruitmentCreatePage.vue
@@ -196,10 +196,16 @@ onMounted(async () => {
     }
 
     const requestId = route.query.id
-    console.log('requestId:', requestId) // 1. requestId 값 확인
+
     if (requestId) {
         requestDetail.value = await fetchRecruitmentRequestDetail(requestId)
-        console.log('requestDetail:', requestDetail.value) // 2. 데이터 도착 확인
+
+        if (requestDetail.value?.startedAt) {
+            form.value.startedAt = requestDetail.value.startedAt.slice(0, 16)
+        }
+        if (requestDetail.value?.endedAt) {
+            form.value.endedAt = requestDetail.value.endedAt.slice(0, 16)
+        }
     }
 })
 

--- a/src/views/employment/RecruitmentDetailPage.vue
+++ b/src/views/employment/RecruitmentDetailPage.vue
@@ -38,7 +38,7 @@ onMounted(async () => {
     const id = route.params.id
     try {
         await store.loadRecruitmentDetail(id)
-        
+
         // 연관된 요청서 정보 불러오기
         if (detail.value.recruitment.recruitmentRequestId) {
             requestDetail.value = await fetchRecruitmentRequestDetail(detail.value.recruitment.recruitmentRequestId)
@@ -56,6 +56,15 @@ function formatDate(date) {
     if (!date) return ''
     return new Date(date).toLocaleString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' })
 }
+
+const getStatusColor = (status) => {
+    switch (status) {
+        case 'WAITING': return 'grey'
+        case 'PUBLISHED': return 'green'
+        case 'CLOSED': return 'red'
+        default: return 'grey'
+    }
+}
 </script>
 
 <template>
@@ -66,9 +75,16 @@ function formatDate(date) {
         <v-card v-else-if="detail" class="pa-6" flat>
             <v-row align="center" justify="space-between" class="mb-6">
                 <v-col cols="auto" class="d-flex align-center">
-                    <v-icon @click="$router.back()" class="me-2 cursor-pointer" size="28"
-                        color="black">mdi-arrow-left</v-icon>
-                    <h2 class="text-h5 font-weight-bold">채용 공고 상세</h2>
+                    <v-icon @click="$router.back()" class="me-2 cursor-pointer" size="28" color="black">
+                        mdi-arrow-left
+                    </v-icon>
+                    <h2 class="text-h5 font-weight-bold me-3">
+                        채용 공고 상세
+                    </h2>
+                    <v-chip v-if="detail?.recruitment?.status !== undefined"
+                        :color="getStatusColor(detail.recruitment.status)" text-color="white" class="ml-2" size="small">
+                        {{ getRecruitStatusLabel(detail.recruitment.status) }}
+                    </v-chip>
                 </v-col>
 
                 <v-col cols="auto" class="d-flex gap-2">
@@ -87,16 +103,12 @@ function formatDate(date) {
                 <div>{{ detail.recruitment.title }}</div>
             </v-card>
             <v-card class="mb-4 pa-4">
-                <div class="font-weight-bold mb-2" style="color: #2f6f3e;">내용</div>
+                <div class="font-weight-bold mb-2" style="color: #2f6f3e;">상세 내용</div>
                 <div v-html="detail.recruitment.content"></div>
             </v-card>
             <v-card class="mb-4 pa-4">
                 <div class="font-weight-bold mb-2" style="color: #2f6f3e;">유형</div>
                 <div>{{ getRecruitTypeLabel(detail.recruitment.recruitType) }}</div>
-            </v-card>
-            <v-card class="mb-4 pa-4">
-                <div class="font-weight-bold mb-2" style="color: #2f6f3e;">상태</div>
-                <div>{{ getRecruitStatusLabel(detail.recruitment.status) }}</div>
             </v-card>
             <v-card class="mb-4 pa-4">
                 <div class="font-weight-bold mb-2" style="color: #2f6f3e;">모집 기간</div>
@@ -108,20 +120,24 @@ function formatDate(date) {
                 <div class="white-space-pre-line">{{ requestDetail.jobName }}</div>
             </v-card>
             <v-card v-if="requestDetail" class="mb-4 pa-4">
-                <div class="font-weight-bold mb-2" style="color: #2f6f3e;">고용 형태</div>
-                <div class="white-space-pre-line">{{ requestDetail.employmentType }}</div>
-            </v-card>
-            <v-card v-if="requestDetail" class="mb-4 pa-4">
-                <div class="font-weight-bold mb-2" style="color: #2f6f3e;">주요 업무</div>
-                <div class="white-space-pre-line">{{ requestDetail.responsibility }}</div>
+                <div class="font-weight-bold mb-2" style="color: #2f6f3e;">부서명</div>
+                <div class="white-space-pre-line">{{ requestDetail.departmentName }}</div>
             </v-card>
             <v-card v-if="requestDetail" class="mb-4 pa-4">
                 <div class="font-weight-bold mb-2" style="color: #2f6f3e;">모집 인원</div>
                 <div>{{ requestDetail.headcount }}명</div>
             </v-card>
             <v-card v-if="requestDetail" class="mb-4 pa-4">
+                <div class="font-weight-bold mb-2" style="color: #2f6f3e;">고용 형태</div>
+                <div class="white-space-pre-line">{{ requestDetail.employmentType }}</div>
+            </v-card>
+            <v-card v-if="requestDetail" class="mb-4 pa-4">
                 <div class="font-weight-bold mb-2" style="color: #2f6f3e;">근무 지역</div>
                 <div>{{ requestDetail.workLocation }}</div>
+            </v-card>
+            <v-card v-if="requestDetail" class="mb-4 pa-4">
+                <div class="font-weight-bold mb-2" style="color: #2f6f3e;">주요 업무</div>
+                <div class="white-space-pre-line">{{ requestDetail.responsibility }}</div>
             </v-card>
             <v-card v-if="requestDetail" class="mb-4 pa-4">
                 <div class="font-weight-bold mb-2" style="color: #2f6f3e;">자격 요건</div>

--- a/src/views/employment/RecruitmentListPage.vue
+++ b/src/views/employment/RecruitmentListPage.vue
@@ -5,19 +5,23 @@
 
         <!-- 공고 현황 요약 -->
         <v-row class="mb-4" align="center">
-            <v-col cols="12" md="2" class="text-center">
-                <div class="text-h6 font-weight-bold">{{ summary.waiting }}</div>
+            <v-col cols="12" md="2" class="text-center" @click="selectedStatus = 'ALL'" style="cursor:pointer">
+                <div class="text-h6 font-weight-bold" :class="{ 'text-success': selectedStatus === 'ALL' }">{{ summary.total }}</div>
+                <div class="text-caption">전체 공고</div>
+            </v-col>
+            <v-col cols="12" md="2" class="text-center" @click="selectedStatus = 'WAITING'" style="cursor:pointer">
+                <div class="text-h6 font-weight-bold" :class="{ 'text-success': selectedStatus === 'WAITING' }">{{ summary.waiting }}</div>
                 <div class="text-caption">대기 중 공고</div>
             </v-col>
-            <v-col cols="12" md="2" class="text-center">
-                <div class="text-h6 font-weight-bold">{{ summary.ongoing }}</div>
+            <v-col cols="12" md="2" class="text-center" @click="selectedStatus = 'PUBLISHED'" style="cursor:pointer">
+                <div class="text-h6 font-weight-bold" :class="{ 'text-success': selectedStatus === 'PUBLISHED' }">{{ summary.ongoing }}</div>
                 <div class="text-caption">게시 중 공고</div>
             </v-col>
-            <v-col cols="12" md="2" class="text-center">
-                <div class="text-h6 font-weight-bold">{{ summary.totalApplicants }}</div>
-                <div class="text-caption">전체 지원자 수</div>
+            <v-col cols="12" md="2" class="text-center" @click="selectedStatus = 'CLOSED'" style="cursor:pointer">
+                <div class="text-h6 font-weight-bold" :class="{ 'text-success': selectedStatus === 'CLOSED' }">{{ summary.closed }}</div>
+                <div class="text-caption">종료 된 공고</div>
             </v-col>
-            <v-col cols="12" md="6" class="d-flex justify-end">
+            <v-col cols="12" md="4" class="d-flex justify-end">
                 <v-btn class="mr-2" variant="outlined" color="success">채용 달력보기</v-btn>
                 <v-btn color="success" dark @click="goToCreate">+ 채용 공고 작성하기</v-btn>
             </v-col>
@@ -42,6 +46,8 @@ const router = useRouter()
 const page = ref(1)
 const totalPages = ref(1)
 const store = useRecruitmentStore()
+
+const selectedStatus = ref('ALL')
 
 function goToCreate() {
     router.push('/employment/recruitments/create')
@@ -73,17 +79,20 @@ const headers = [
 ]
 
 const summary = computed(() => ({
+    total: store.list.length,
     waiting: store.list.filter(r => r.status === 'WAITING').length,
     ongoing: store.list.filter(r => r.status === 'PUBLISHED').length,
-    totalApplicants: 150 // TODO: 실제 API 연결 시 수정
+    closed: store.list.filter(r => r.status === 'CLOSED').length,
 }))
 
 const recruitmentsForDisplay = computed(() =>
-    store.list.map(r => ({
-        ...r,
-        recruitType: getRecruitTypeLabel(r.recruitType),
-        status: getRecruitStatusLabel(r.status)
-    }))
+    store.list
+        .filter(r => selectedStatus.value === 'ALL' ? true : r.status === selectedStatus.value)
+        .map(r => ({
+            ...r,
+            recruitType: getRecruitTypeLabel(r.recruitType),
+            status: getRecruitStatusLabel(r.status)
+        }))
 )
 </script>
 

--- a/src/views/employment/RecruitmentRequestCreateView.vue
+++ b/src/views/employment/RecruitmentRequestCreateView.vue
@@ -6,15 +6,13 @@
             <v-row dense>
                 <!-- 포지션 -->
                 <v-col cols="12">
-                    <v-select v-model="form.jobId" :items="jobOptions" label="포지션" item-title="name" item-value="id"
-                        :rules="[required]" />
+                    <v-select v-model="form.jobId" :items="store.jobList" item-title="name" item-value="id"
+                        label="포지션" />
                 </v-col>
 
                 <!-- 부서 -->
-                <v-col cols="12">
-                    <v-select v-model="form.departmentId" :items="departmentOptions" label="부서" item-title="name"
-                        item-value="id" :rules="[required]" />
-                </v-col>
+                <v-select v-model="form.departmentId" :items="store.departmentList" item-title="name" item-value="id"
+                    label="부서" />
 
                 <!-- 모집 인원 -->
                 <v-col cols="12">
@@ -68,7 +66,7 @@
 </template>
 
 <script setup>
-import { ref } from 'vue';
+import { ref, onMounted } from 'vue';
 import dayjs from 'dayjs';
 import { useRouter } from 'vue-router';
 import { useRecruitmentRequestStore } from '@/stores/recruitmentRequestStore';
@@ -101,17 +99,12 @@ const form = ref({
     workLocation: ''
 });
 
+onMounted(() => {
+    store.loadJobList();
+    store.loadDepartmentList();
+});
+
 // 더미 옵션
-const jobOptions = [
-    { id: 1, name: '프론트엔드 개발자' },
-    { id: 2, name: '백엔드 개발자' }
-];
-
-const departmentOptions = [
-    { id: 1, name: '개발팀' },
-    { id: 2, name: '디자인팀' }
-];
-
 const employmentTypes = ['정규직', '계약직', '인턴'];
 
 // 유효성 검사


### PR DESCRIPTION
### 🪄 PR 타입
- [x] 신규 기능
- [ ] 기능 수정
- [x] 리팩토링
- [ ] 버그 픽스

### 📝 변경 사항
* 채용 요청서에 직무, 부서 드롭다운 추가
* 채용요청서에서 공고 작성 시 요청서 내용 작성화면에 띄우기
* 날짜 연동
* 공고 게시 상태 별 필터 추가

### 📷 관련 스크린샷
![image](https://github.com/user-attachments/assets/dcc04e42-accb-476f-8363-258ea49dc3af)
![image](https://github.com/user-attachments/assets/3e73dd91-4a2b-4dcb-b3cc-f04d24aa667c)
![image](https://github.com/user-attachments/assets/aa83c917-2524-4c72-b3b5-d3a3f3dd14fc)


### 🧪 테스트 계획 또는 완료 사항

- [채용 요청서 작성](http://localhost:8080/employment/recruitment-requests/create)
- [요청서 연동 확인(공고 작성 버튼 누르면 이동)](http://localhost:8080/employment/recruitment-requests/2024)
