### PR TITLE
[feat] 실무테스트 할당 모달 생성

### DIFF
--- a/src/components/employment/JobtestSelectModal.vue
+++ b/src/components/employment/JobtestSelectModal.vue
@@ -1,0 +1,29 @@
+<template>
+<v-dialog :model-value="modelValue" @update:modelValue="emit('update:modelValue', $event)" max-width="1200">
+        <v-card>
+            <v-card-title>실무 테스트 선택</v-card-title>
+            <v-card-text>
+                <v-list>
+                    <v-list-item v-for="jobtest in jobtests" :key="jobtest.id" @click="select(jobtest)">
+                        <v-list-item-title>{{ jobtest.title }}</v-list-item-title>
+                    </v-list-item>
+                </v-list>
+            </v-card-text>
+        </v-card>
+    </v-dialog>
+</template>
+
+<script setup>
+import { defineProps, defineEmits } from 'vue'
+
+const props = defineProps({
+    modelValue: Boolean,
+    jobtests: Array
+});
+const emit = defineEmits(['update:modelValue', 'select']);
+
+const select = (jobtest) => {
+    emit('select', jobtest);
+    emit('update:modelValue', false);
+};
+</script>

--- a/src/dto/employment/jobtest/applicationJobtestDTO.js
+++ b/src/dto/employment/jobtest/applicationJobtestDTO.js
@@ -1,0 +1,30 @@
+export default class CreateApplicationJobtestCommandDTO {
+    constructor(applicationId, jobtestId, entryCode) {
+        this.applicationId = applicationId;
+        this.jobtestId = jobtestId;
+        this.entryCode = entryCode;
+    }
+
+    toJSON() {
+        return {
+            evaluatorComment: this.evaluatorComment,
+            submittedAt: this.submittedAt,
+            gradingTotalScore: this.gradingTotalScore,
+            evaluationScore: this.evaluationScore,
+            gradingStatus: this.gradingStatus,
+            evaluationStatus: this.evaluationStatus,
+            entryCode: this.entryCode,
+            applicationId: this.applicationId,
+            jobtestId: this.jobtestId,
+            memberId: this.memberId
+        };
+    }
+
+    static fromForm(json) {
+        return new CreateApplicationJobtestCommandDTO(
+            json.applicationId,
+            json.jobtestId,
+            json.entryCode
+        );
+    }
+}

--- a/src/router/test.routes.js
+++ b/src/router/test.routes.js
@@ -51,5 +51,13 @@ export const testRoutes = [
         path: '/WSPage',
         name: 'WSPage',
         component: () => import('@/views/test/WSPage.vue')
+    },
+    {
+        path: '/employment/applications/test-assign',
+        name: 'ApplicationAssignTest',
+        component: () => import('@/views/test/ApplicationAssignTestPage.vue'),
+        meta: { requiresAuth: true }
     }
+
+
 ]; 

--- a/src/services/jobtestService.js
+++ b/src/services/jobtestService.js
@@ -52,3 +52,18 @@ export const createJobtestService = async (
         return apiResponse.message;
     }, options);
 }
+
+// 지원서에 실무테스트 할당
+export const createApplicationJobtestService = async (
+    dto,
+    options = {}
+) => {
+    return withErrorHandling(async () => {
+        const response = await api.post(JobtestAPI.APPLICATION_JOBTESTS, dto);
+        const apiResponse = ApiResponseDTO.fromJSON(response.data);
+        if (!apiResponse.success) {
+            throwCustomApiError(apiResponse.code, apiResponse.message, 400);
+        }
+        return apiResponse.data;
+    }, options);
+}

--- a/src/stores/applicationJobtestStore.js
+++ b/src/stores/applicationJobtestStore.js
@@ -1,0 +1,26 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+import { createApplicationJobtestService } from '@/services/jobtestService';
+
+export const useApplicationJobtestStore = defineStore('applicationJobtest', () => {
+    const errorMessage = ref('');
+
+    const assignJobtest = async (dtoList) => {
+        errorMessage.value = '';
+        try {
+            for (const dto of dtoList) {
+                console.log(dto.applicationId);
+                
+                await createApplicationJobtestService(dto, { showToast: false, redirect: false });
+            }
+        } catch (e) {
+            errorMessage.value = e?.message || '문제 할당 중 오류가 발생했습니다.';
+            throw e;
+        }
+    };
+
+    return {
+        assignJobtest,
+        errorMessage
+    };
+});

--- a/src/views/test/ApplicationAssignTestPage.vue
+++ b/src/views/test/ApplicationAssignTestPage.vue
@@ -1,0 +1,89 @@
+<template>
+    <v-container>
+        <h2 class="text-h6 font-weight-bold mb-4">지원자 목록 (테스트용)</h2>
+
+        <v-data-table :headers="headers" :items="dummyApplications" item-value="id" class="mb-4">
+            <!-- 체크 아이콘 버튼 -->
+            <template #item.actions="{ item }">
+                <v-btn size="small" icon :color="selectedIds.includes(item.id) ? 'primary' : 'grey-lighten-1'"
+                    variant="tonal" @click="toggleSelection(item.id)">
+                    <v-icon>
+                        {{ selectedIds.includes(item.id) ? 'mdi-checkbox-marked' : 'mdi-checkbox-blank-outline' }}
+                    </v-icon>
+                </v-btn>
+            </template>
+        </v-data-table>
+
+        <div class="d-flex justify-end mb-4">
+            <v-btn color="primary" @click="handleAssignClick" :disabled="!selectedIds.length">
+                실무 테스트 할당
+            </v-btn>
+        </div>
+
+        <!-- 실무 테스트 선택 모달 -->
+        <JobtestSelectModal v-model="jobtestModal" :jobtests="jobtestListStore.jobtests"
+            @select="handleJobtestSelected" />
+    </v-container>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import { useToast } from 'vue-toastification';
+import { useJobtestListStore } from '@/stores/jobtestListStore';
+import { useApplicationJobtestStore } from '@/stores/applicationJobtestStore';
+import ApplicationJobtestDTO from '@/dto/employment/jobtest/applicationJobtestDTO';
+import JobtestSelectModal from '@/components/employment/JobtestSelectModal.vue';
+
+const selectedIds = ref([]);
+const jobtestModal = ref(false);
+const toast = useToast();
+
+const dummyApplications = [
+    { id: 1, name: '김지원 지원서', email: 'kim@example.com' },
+    { id: 3, name: '이승훈 지원서', email: 'lee@example.com' },
+    { id: 4, name: '박하늘 지원서', email: 'park@example.com' }
+];
+
+const headers = [
+    { text: '', value: 'actions', sortable: false, width: 48 }, // ⬅ 체크 아이콘용
+    { text: '이름', value: 'name' },
+    { text: '이메일', value: 'email' }
+];
+
+const jobtestListStore = useJobtestListStore();
+const applicationJobtestStore = useApplicationJobtestStore();
+
+const toggleSelection = (id) => {
+    const idx = selectedIds.value.indexOf(id);
+    if (idx > -1) {
+        selectedIds.value.splice(idx, 1);
+    } else {
+        selectedIds.value.push(id);
+    }
+};
+
+const handleAssignClick = async () => {
+    try {
+        await jobtestListStore.fetchJobtests();
+        jobtestModal.value = true;
+    } catch (e) {
+        toast.error('실무 테스트 목록을 불러오는 데 실패했습니다.');
+    }
+};
+
+const handleJobtestSelected = async (jobtest) => {
+    jobtestModal.value = false;
+
+    const dtoList = selectedIds.value.map(appId => {
+        const entryCode = crypto.randomUUID().slice(0, 8).toUpperCase();
+        return new ApplicationJobtestDTO(appId, jobtest.id, entryCode);
+    });
+
+    try {
+        await applicationJobtestStore.assignJobtest(dtoList);
+        toast.success('선택한 지원서에 문제를 성공적으로 할당했습니다.');
+    } catch (e) {
+        toast.error(applicationJobtestStore.errorMessage);
+    }
+};
+</script>


### PR DESCRIPTION
### 🪄 PR 타입

- [X] 신규 기능
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] 버그 픽스

### #️⃣ 연관된 이슈

close #이슈번호

### 📝 변경 사항
- 지원자 목록 체크박스 수정
- 선택한 지원서에 실무테스트 선택 후 할당

---

### 💬 참고사항
- 백엔드의 https://github.com/Pive-Guyz/be14-fin-Empick-BE/pull/276 PR을 머지해야 오류가 나지 않습니다.
- 지원서 목록 테이블의 체크박스가 id 값을 받아오지 못해서 버튼으로 수정했습니다.
- 현재 지원자 id로 들어가고 있습니다. 지원서 목록 페이지에서 지원서 id를 저장하면 그걸 기준으로 저장할 예정입니다.
- 이미 할당되어있는 지원자라면 오류 토스트가 뜹니다. 에러 메세지가 커스텀으로 뜨지 않는 버그를 수정해야 합니다.
- 이미 실무테스트가 할당되어 있는 지원자를 프론트에서 보여줄 방법이 있으면 좋을 것 같습니다. 방법은 고민중입니다..

### 📷 관련 스크린샷
![{B972134E-4DE5-485E-A360-9A12E2CCD629}](https://github.com/user-attachments/assets/56660350-7da4-4f23-aed3-e8e8dba811f0)



### 🧪 테스트 계획 또는 완료 사항

- [ ] [지원자 목록 페이지에서 지원자 선택 후 실무테스트 할당](http://localhost:8080/employment/applicant)
