### PR TITLE
[feat] 실무테스트 문제 삭제 기능 추가

### DIFF
--- a/src/components/common/ListView.vue
+++ b/src/components/common/ListView.vue
@@ -4,7 +4,7 @@
         <v-table class="mt-5">
             <thead>
                 <tr>
-                    <th v-if="showCheckbox" style="width: 48px;"></th>
+                    <th v-if="showCheckbox" style="width: 80px;">선택</th>
                     <th v-for="header in headers" :key="header.key">
                         {{ header.label }}
                     </th>
@@ -12,9 +12,15 @@
                 </tr>
             </thead>
             <tbody>
-                <tr v-for="(item, index) in data" :key="index" @click="$emit('item-click', item)" style="cursor: pointer;">
-                    <td v-if="showCheckbox">
-                        <v-checkbox v-model="item.selected" :ripple="false" hide-details density="compact" />
+                <tr v-for="(item, index) in data" :key="index" @click="$emit('item-click', item)"
+                    style="cursor: pointer;">
+                    <td v-if="showCheckbox" @click.stop>
+                        <v-btn size="small" icon :color="item.selected ? 'primary' : 'grey-lighten-1'" variant="tonal"
+                            @click.stop="$emit('toggle-select', item.id)">
+                            <v-icon>
+                                {{ item.selected ? 'mdi-checkbox-marked' : 'mdi-checkbox-blank-outline' }}
+                            </v-icon>
+                        </v-btn>
                     </td>
                     <td v-for="header in headers" :key="header.key">
                         <template v-if="header.key === 'avatarName' && item.avatar && item.name">

--- a/src/services/jobtestQuestionService.js
+++ b/src/services/jobtestQuestionService.js
@@ -53,3 +53,32 @@ export const createQuestionService = async (
         return apiResponse.message;
     }, options);
 };
+
+// 실무테스트 문제 삭제
+export const deleteQuestionService = async (
+    questionId,
+    options = {}
+) => {
+    return withErrorHandling(async () => {
+        const response = await api.delete(JobtestAPI.QUESTION_DETAIL(questionId));
+        const apiResponse = ApiResponseDTO.fromJSON(response.data);
+
+        if (!apiResponse.success) {
+            throwCustomApiError(apiResponse.code, apiResponse.message, 400);
+        }
+
+        return apiResponse.message;
+    }, options);
+};
+
+// 선택지 전체 삭제 (문제 ID 기준)
+export const deleteQuestionOptionsByQuestionId = async (questionId, options = {}) => {
+    return withErrorHandling(async () => {
+        const response = await api.delete(JobtestAPI.QUESTION_OPTION_DETAIL(questionId));
+        const apiResponse = ApiResponseDTO.fromJSON(response.data);
+        if (!apiResponse.success) {
+            throwCustomApiError(apiResponse.code, apiResponse.message, 400);
+        }
+        return apiResponse.message;
+    }, options);
+};

--- a/src/views/employment/JobtestQuestionListPage.vue
+++ b/src/views/employment/JobtestQuestionListPage.vue
@@ -32,7 +32,7 @@
                 <!-- 문제 리스트 -->
 
                 <ListView :headers="headers" :data="jobtestStore.questions" :showCheckbox="true"
-                    @item-click="handleItemClick" />
+                    @item-click="handleItemClick" @toggle-select="jobtestStore.toggleQuestionSelection" />
 
                 <QuestionDetailModal v-model="detailDialogVisible" :question="selectedQuestionDetail" />
             </v-container>
@@ -50,6 +50,10 @@ import { useJobtestStore } from '@/stores/jobtestQuestionStore'
 
 import { getQuestionDetailService } from '@/services/jobtestQuestionService'
 import QuestionDetailModal from '@/components/employment/JobtestQuestionDetailModal.vue'
+import { useToast } from 'vue-toastification';
+
+
+const toast = useToast();
 
 const router = useRouter()
 const jobtestStore = useJobtestStore()
@@ -64,6 +68,7 @@ const headers = [
     { label: '수정자', key: 'updatedMemberName' },
 ]
 
+
 const handleItemClick = async (item) => {
     try {
         const detail = await getQuestionDetailService(item.id)
@@ -74,10 +79,15 @@ const handleItemClick = async (item) => {
     }
 }
 // 삭제 처리
-const handleDelete = () => {
-    const selectedIds = jobtestStore.getSelectedQuestionIds()
-    console.log('Selected questions:', selectedIds)
-    // TODO: 선택된 문제 삭제 로직 구현
+const handleDelete = async () => {
+    if (!confirm('선택된 문제를 삭제하시겠습니까?')) return;
+
+    try {
+        await jobtestStore.deleteSelectedQuestions();
+        toast.success('선택된 문제가 삭제되었습니다.');
+    } catch (err) {
+        toast.error('문제 삭제 중 오류가 발생했습니다.');
+    }
 }
 
 // 문제 등록


### PR DESCRIPTION
### 🪄 PR 타입

- [X] 신규 기능
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] 버그 픽스

### #️⃣ 연관된 이슈

close #이슈번호

### 📝 변경 사항
- 실무테스트 문제 삭제 기능 추가

---

### 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분
- 실무테스트에 등록되어 있는 경우는 삭제 불가합니다.
- 선택형 문제 삭제 시 관련 선택지도 모두 삭제됩니다.
- 백엔드의 https://github.com/Pive-Guyz/be14-fin-Empick-BE/pull/278 PR을 머지하셔야 오류가 안납니다.

### 📷 관련 스크린샷
- 삭제 안되는 경우
![{E850FAD8-4352-40FB-89C8-54742FC0A6BB}](https://github.com/user-attachments/assets/9567d894-7652-4f24-9735-3b298d09c14b)

- 삭제 성공한 경우
![{6E8D78B0-BB0B-4379-ACCB-F7222850D1C2}](https://github.com/user-attachments/assets/9dd942af-a5d1-4843-ae05-704d8e0a571a)


### 🧪 테스트 계획 또는 완료 사항

- [ ] [실무테스트 문제 목록](http://localhost:8080/employment/jobtest-questions)