### PR TITLE
[feat] 요청받은 결재 목록 페이지 구현

### DIFF
--- a/src/apis/routes/approval.js
+++ b/src/apis/routes/approval.js
@@ -24,4 +24,7 @@ export const ApprovalAPI = {
     // 작성자 or 결재자 기준 목록 조회
     DOCUMENTS_BY_WRITER: (writerId) => `/api/v1/approval/documents?writerId=${writerId}`,
     DOCUMENTS_BY_APPROVER: (approverId) => `/api/v1/approval/documents?approverId=${approverId}`,
+    
+    // 자신이 결재자인 결재문서 목록 조회
+    RECEIVED_DOCUMENTS: (memberId) => `/api/v1/approval/received?memberId=${memberId}`,
 };

--- a/src/components/common/ListView.vue
+++ b/src/components/common/ListView.vue
@@ -44,6 +44,10 @@
                                 {{ item.status }}
                             </v-chip>
                         </template>
+                        <template v-else-if="header.key === 'isMyTurn'">
+                            <v-chip v-if="item.canApproveChip" color="success" text-color="white" small>결재 가능</v-chip>
+                            <span v-else>{{ item.isMyTurn }}</span>
+                        </template>
                         <template v-else>
                             {{ item[header.key] }}
                         </template>

--- a/src/dto/approval/approval/approvalReceivedListDTO.js
+++ b/src/dto/approval/approval/approvalReceivedListDTO.js
@@ -1,0 +1,11 @@
+export default class approvalReceivedListDTO {
+    constructor(data) {
+        this.approvalId = data.approvalId;
+        this.categoryName = data.categoryName;
+        this.writerName = data.writerName;
+        this.createdAt = data.createdAt;
+        this.status = data.status;
+        this.myApprovalStep = data.myApprovalStep;
+        this.isMyTurn = data.isMyTurn;
+    }
+}

--- a/src/services/approvalService.js
+++ b/src/services/approvalService.js
@@ -2,6 +2,7 @@ import api from '@/apis/apiClient';
 import { ApprovalAPI } from '@/apis/routes/approval';
 import ApiResponseDTO from '@/dto/common/apiResponseDTO';
 import { withErrorHandling, throwCustomApiError } from '@/utils/errorHandler';
+import ApprovalReceivedListDTO from '@/dto/approval/approval/approvalReceivedListDTO';
 
 // 결재 문서 목록 조회 (작성자 기준)
 export const getApprovalsByWriterId = async (writerId) => {  };
@@ -20,3 +21,9 @@ export const approveApproval = async (approvalId) => {  };
 
 // 반려 처리
 export const rejectApproval = async (approvalId, rejectReason) => {  };
+
+// 자신이 결재자인 결재문서 목록 조회
+export const getReceivedApprovals = async (memberId) => {
+    const res = await api.get(ApprovalAPI.RECEIVED_DOCUMENTS(memberId));
+    return res.data.data.map(item => new ApprovalReceivedListDTO(item));
+};

--- a/src/stores/approvalStore.js
+++ b/src/stores/approvalStore.js
@@ -1,0 +1,23 @@
+import { defineStore } from 'pinia';
+import { getReceivedApprovals } from '@/services/approvalService';
+
+export const useApprovalStore = defineStore('approval', {
+    state: () => ({
+        receivedList: [],
+        loadingReceived: false,
+        errorReceived: null,
+    }),
+    actions: {
+        async loadReceivedApprovals(memberId) {
+            this.loadingReceived = true;
+            this.errorReceived = null;
+            try {
+                this.receivedList = await getReceivedApprovals(memberId);
+            } catch (e) {
+                this.errorReceived = e;
+            } finally {
+                this.loadingReceived = false;
+            }
+        }
+    }
+});

--- a/src/stores/authStore.js
+++ b/src/stores/authStore.js
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia';
 import { ref } from 'vue';
 import { loginService, logoutService } from '@/services/authService';
 import { useRouter } from 'vue-router';
+import { useMemberStore } from '@/stores/memberStore'
 
 import { jwtDecode } from 'jwt-decode';
 
@@ -85,6 +86,8 @@ console.log('userInfo.value (최종)', userInfo.value);
             accessToken.value = '';
             refreshToken.value = '';
             userInfo.value = null;
+
+            useMemberStore().reset();
 
             // 로그아웃 후 로그인 페이지로 이동
             router.push('/login');

--- a/src/stores/memberStore.js
+++ b/src/stores/memberStore.js
@@ -26,6 +26,28 @@ export const useMemberStore = defineStore('member', {
         defaultProfileImageUrl: '/images/default-profile.png'
     }),
     actions: {
+        reset() {
+            this.form = {
+                id: null,
+                employeeNumber: null,
+                name: '',
+                email: '',
+                phone: '',
+                departmentName: '',
+                positionName: '',
+                jobName: '',
+                rankName: '',
+                pictureUrl: '',
+                status: 0,
+                hireAt: null,
+                resignAt: null
+            };
+            this.registerResult = null;
+            this.registerError = null;
+            this.loading = false;
+            this.error = '';
+            this.profileImageUrl = '';
+        },
         async registerMember(memberData) {
             this.loading = true;
             this.registerError = null;

--- a/src/views/approval/ApprovalInboxPage.vue
+++ b/src/views/approval/ApprovalInboxPage.vue
@@ -1,9 +1,68 @@
 <template>
-    <v-container fluid>
-        <h2 class="text-h5 font-weight-bold mb-4">받은 결재 목록</h2>
+    <v-container class="pa-6">
+        <h2 class="text-h5 font-weight-bold mb-6">받은 결재 목록</h2>
+        <v-alert v-if="error" type="error" class="mb-4">{{ error }}</v-alert>
+        <v-progress-circular v-if="loading" indeterminate color="primary" class="mb-4" />
+        <ListView v-else :headers="headers" :data="pagedList" @item-click="goToDetail" />
+        <Pagination v-model="page" :length="totalPages" />
     </v-container>
 </template>
 
 <script setup>
+import { ref, onMounted, computed } from 'vue';
+import { useRouter } from 'vue-router';
+import { useApprovalStore } from '@/stores/approvalStore';
+import { useMemberStore } from '@/stores/memberStore';
+import ListView from '@/components/common/ListView.vue';
+import Pagination from '@/components/common/Pagination.vue';
+import dayjs from 'dayjs';
 
+const approvalStore = useApprovalStore();
+const memberStore = useMemberStore();
+const router = useRouter();
+
+const receivedList = computed(() => approvalStore.receivedList);
+const loading = computed(() => approvalStore.loadingReceived);
+const error = computed(() => approvalStore.errorReceived);
+
+const headers = [
+    { key: 'approvalId', label: '문서번호' },
+    { key: 'categoryName', label: '카테고리' },
+    { key: 'writerName', label: '작성자' },
+    { key: 'status', label: '상태' },
+    { key: 'myApprovalStep', label: '결재순서' },
+    { key: 'isMyTurn', label: '결재차례' },
+    { key: 'createdAt', label: '작성일' },
+];
+
+const itemsPerPage = ref(10);
+const page = ref(1);
+
+const pagedList = computed(() => {
+    const start = (page.value - 1) * itemsPerPage.value;
+    const end = start + itemsPerPage.value;
+    return receivedList.value.slice(start, end).map(item => ({
+        ...item,
+        isMyTurn: item.isMyTurn === 1 ? '내 차례' : '-',
+        createdAt: item.createdAt ? dayjs(item.createdAt).format('YYYY-MM-DD HH:mm') : '',
+    }));
+});
+
+const totalPages = computed(() => Math.ceil(receivedList.value.length / itemsPerPage.value));
+
+function goToDetail(item) {
+    if (item && item.approvalId) {
+        router.push(`/approval/${item.approvalId}`);
+    }
+}
+
+onMounted(async () => {
+    // 내 정보가 없으면 먼저 불러오기
+    if (!memberStore.form.id) {
+        await memberStore.getMyInfo();
+    }
+    if (memberStore.form.id) {
+        approvalStore.loadReceivedApprovals(memberStore.form.id);
+    }
+});
 </script>


### PR DESCRIPTION
### 🪄 PR 타입
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] 버그 픽스

### 📝 변경 사항
* 요청받은 결재 목록 페이지 구현
* 로그아웃 시 사원 정보가 초기화 되지 않아 memberStore에 reset() 추가

### 💬 리뷰 요구사항
* 백엔드 feature/hm/received_approval 브랜치에서 확인 부탁드립니다!

### 📷 관련 스크린샷
* 결재 차례일 때
![image](https://github.com/user-attachments/assets/d211d88f-db46-48f0-9195-4bd94b585a94)

* 결재 차례가 아닐 때
![image](https://github.com/user-attachments/assets/e063faba-4692-45cf-8e07-b5e5d0cbeba5)

### 🧪 테스트 완료 사항
- [요청받은 결재 목록 페이지](http://localhost:8080/approval/inbox)

