### PR TITLE
[feat] 채용요청 결재 완료 시 채용요청서 연동 기능 구현

### DIFF
--- a/src/services/recruitmentRequestService.js
+++ b/src/services/recruitmentRequestService.js
@@ -22,7 +22,6 @@ export const fetchRecruitmentRequestList = async (options = {}) => {
 export const fetchRecruitmentRequestDetail = async (id, options = {}) => {
     return withErrorHandling(async () => {
         const response = await api.get(API.RECRUITMENT.REQUEST_DETAIL(id));
-        console.log('📡 요청서 응답', response.data);
         const apiResponse = ApiResponseDTO.fromJSON(response.data);
 
         if (!apiResponse.success) {

--- a/src/stores/recruitmentRequestStore.js
+++ b/src/stores/recruitmentRequestStore.js
@@ -61,10 +61,11 @@ export const useRecruitmentRequestStore = defineStore('recruitmentRequest', () =
         }
     };
 
-    // 상세 불러오기
+    // 상세 정보 불러오기
     const loadRecruitmentRequestDetail = async (id) => {
         loadingDetail.value = true;
         detailError.value = null;
+
         try {
             const result = await fetchRecruitmentRequestDetail(id);
             recruitmentRequestDetail.value = result;
@@ -75,13 +76,14 @@ export const useRecruitmentRequestStore = defineStore('recruitmentRequest', () =
         }
     };
 
-    // 등록 함수
-    const submitRecruitmentRequest = async (formDTO) => {
+    // 요청서 등록
+    const submitRecruitmentRequest = async (dto) => {
         submitting.value = true;
         submitError.value = null;
 
         try {
-            await createRecruitmentRequest(formDTO);
+            const result = await createRecruitmentRequest(dto);
+            return result;
         } catch (err) {
             submitError.value = err.message;
             throw err;
@@ -91,26 +93,22 @@ export const useRecruitmentRequestStore = defineStore('recruitmentRequest', () =
     };
 
     return {
-        // 목록 관련
+        // 상태
         recruitmentRequestList,
         loadingRecruitmentRequest,
         recruitmentRequestError,
-        loadRecruitmentRequestList,
-
-        // 상세 관련
         recruitmentRequestDetail,
         loadingDetail,
         detailError,
-        loadRecruitmentRequestDetail,
-
-        // 등록 관련
         submitting,
         submitError,
-        submitRecruitmentRequest,
-
-        // 직무, 부서
         jobList,
         departmentList,
+
+        // 액션
+        loadRecruitmentRequestList,
+        loadRecruitmentRequestDetail,
+        submitRecruitmentRequest,
         loadJobList,
         loadDepartmentList,
     };

--- a/src/views/approval/ApprovaRequestedDetailPage.vue
+++ b/src/views/approval/ApprovaRequestedDetailPage.vue
@@ -1,6 +1,6 @@
 <template>
     <div v-if="loading" class="loading-container">
-        <p>로딩 중...</p>
+        <v-progress-circular indeterminate color="primary"></v-progress-circular>
     </div>
     <div v-else-if="error" class="error-container">
         <p>오류가 발생했습니다: {{ error.message }}</p>
@@ -11,7 +11,10 @@
 
     <div v-else class="page-container">
         <div class="header">
-            <h1 class="page-title">요청한 결재 문서 조회</h1>
+            <div class="header-left">
+                <v-icon @click="$router.back()" class="mr-4 cursor-pointer">mdi-arrow-left</v-icon>
+                <h1 class="page-title">요청한 결재 문서 조회</h1>
+            </div>
             <v-btn
                 v-if="isRecruitmentRequest && isApproved"
                 @click="handleLinkRecruitmentRequest"
@@ -19,10 +22,10 @@
                 variant="flat"
                 :loading="linking"
             >
-                채용 요청서로 생성
+                채용 요청서 생성
             </v-btn>
         </div>
-
+        <hr />
         <div class="content-section">
             <table class="info-table">
                 <tbody>
@@ -279,10 +282,14 @@ onUnmounted(() => {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: 1.5rem;
+    margin-bottom: 20px;
+}
+.header-left {
+    display: flex;
+    align-items: center;
 }
 .page-title {
-    font-size: 1.8rem;
+    font-size: 24px;
     font-weight: 600;
 }
 .content-section {
@@ -434,5 +441,8 @@ h3 {
 }
 .disclaimer p {
     margin: 0.3rem 0;
+}
+.cursor-pointer {
+    cursor: pointer;
 }
 </style>

--- a/src/views/approval/ApprovaRequestedDetailPage.vue
+++ b/src/views/approval/ApprovaRequestedDetailPage.vue
@@ -12,6 +12,15 @@
     <div v-else class="page-container">
         <div class="header">
             <h1 class="page-title">요청한 결재 문서 조회</h1>
+            <v-btn
+                v-if="isRecruitmentRequest && isApproved"
+                @click="handleLinkRecruitmentRequest"
+                color="primary"
+                variant="flat"
+                :loading="linking"
+            >
+                채용 요청서로 생성
+            </v-btn>
         </div>
 
         <div class="content-section">
@@ -66,7 +75,7 @@
                     <template v-for="item in approvalDetail.items" :key="item.itemName">
                         <div class="form-row">
                             <label>{{ item.itemName }}</label>
-                            <span>{{ item.content }}</span>
+                            <span>{{ getItemContent(item) }}</span>
                         </div>
                     </template>
                 </div>
@@ -79,20 +88,91 @@
 </template>
 
 <script setup>
-import { onMounted, onUnmounted } from 'vue';
-import { useRoute } from 'vue-router';
+import { onMounted, onUnmounted, computed, ref } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
 import { storeToRefs } from 'pinia';
 import { useApprovalStore } from '../../stores/approvalStore';
+import { useDepartmentStore } from '@/stores/departmentStore';
+import { useJobStore } from '@/stores/jobStore';
+import { useRecruitmentRequestStore } from '@/stores/recruitmentRequestStore';
+import RecruitmentRequestCreateDTO from '@/dto/employment/recruitment/RecruitmentRequestCreateDTO';
 
 defineProps({
     id: { type: String, required: true }
 });
 
 const route = useRoute();
+const router = useRouter();
 const approvalStore = useApprovalStore();
+const departmentStore = useDepartmentStore();
+const jobStore = useJobStore();
+const recruitmentRequestStore = useRecruitmentRequestStore();
 
 const { approvalDetail, loading, error } = storeToRefs(approvalStore);
+const { departmentList } = storeToRefs(departmentStore);
+const { jobList } = storeToRefs(jobStore);
+
 const { fetchRequestedApprovalDetail, clearApprovalDetail } = approvalStore;
+const { loadDepartmentList } = departmentStore;
+const { loadJobList } = jobStore;
+
+const linking = ref(false);
+
+const isRecruitmentRequest = computed(() => approvalDetail.value?.categoryId === 401);
+const isApproved = computed(() => approvalDetail.value?.status === 'APPROVED');
+
+const handleLinkRecruitmentRequest = async () => {
+    if (!approvalDetail.value) return;
+
+    linking.value = true;
+    try {
+        const itemMap = new Map(approvalDetail.value.items.map(i => [i.itemName, i.content]));
+
+        const dto = new RecruitmentRequestCreateDTO(
+            parseInt(itemMap.get('직무'), 10),
+            parseInt(itemMap.get('부서'), 10),
+            parseInt(itemMap.get('모집 인원'), 10),
+            `${itemMap.get('모집 시작일')}T00:00:00`,
+            `${itemMap.get('모집 마감일')}T23:59:59`,
+            itemMap.get('지원자격'),
+            itemMap.get('우대사항'),
+            itemMap.get('주요업무'),
+            itemMap.get('고용형태'),
+            itemMap.get('근무 지역')
+        );
+
+        await recruitmentRequestStore.submitRecruitmentRequest(dto);
+        
+        alert('채용 요청서가 성공적으로 생성되었습니다.');
+        router.push('/employment/recruitment-requests');
+
+    } catch (err) {
+        console.error("Failed to create recruitment request:", err);
+        alert(`채용 요청서 생성에 실패했습니다: ${err.message}`);
+    } finally {
+        linking.value = false;
+    }
+};
+
+const getDepartmentName = (id) => {
+    const department = departmentList.value.find(d => d.id === Number(id));
+    return department ? department.name : id;
+}
+
+const getJobName = (id) => {
+    const job = jobList.value.find(j => j.id === Number(id));
+    return job ? job.name : id;
+}
+
+const getItemContent = (item) => {
+    if (item.itemName === '부서') {
+        return getDepartmentName(item.content);
+    }
+    if (item.itemName === '직무') {
+        return getJobName(item.content);
+    }
+    return item.content;
+}
 
 const formatDate = (dateString, format = 'full') => {
     if (!dateString) return '';
@@ -170,6 +250,10 @@ const getApproverStatusClass = (approver) => {
 };
 
 onMounted(async () => {
+    await Promise.all([
+        loadDepartmentList(),
+        loadJobList()
+    ]);
     const approvalId = parseInt(route.params.id);
     if (approvalId) {
         await fetchRequestedApprovalDetail(approvalId);

--- a/src/views/approval/ApprovalReceivedDetailPage.vue
+++ b/src/views/approval/ApprovalReceivedDetailPage.vue
@@ -1,6 +1,6 @@
 <template>
     <div v-if="loading" class="loading-container">
-        <p>로딩 중...</p>
+        <v-progress-circular indeterminate color="primary"></v-progress-circular>
     </div>
     <div v-else-if="error" class="error-container">
         <p>오류가 발생했습니다: {{ error.message }}</p>
@@ -11,7 +11,10 @@
 
     <div v-else class="page-container">
         <div class="header">
-            <h1 class="page-title">결재 문서 조회</h1>
+            <div class="header-left">
+                <v-icon @click="$router.back()" class="mr-4 cursor-pointer">mdi-arrow-left</v-icon>
+                <h1 class="page-title">결재 문서 조회</h1>
+            </div>
             <div class="action-buttons">
                 <v-btn
                     v-if="isRecruitmentRequest && isApproved"
@@ -21,7 +24,7 @@
                     class="mr-4"
                     :loading="linking"
                 >
-                    채용 요청서로 생성
+                    채용 요청서 생성
                 </v-btn>
                 <button class="btn approve" @click="handleApprove" :disabled="!canApprove">
                     승인
@@ -31,69 +34,71 @@
                 </button>
             </div>
         </div>
+        <hr />
+        <div v-if="approvalDetail" class="approval-detail-container">
+            <div class="document-info">
+                <table class="info-table">
+                    <tbody>
+                        <tr>
+                            <th>결재 유형</th>
+                            <td>{{ approvalDetail.categoryName }}</td>
+                            <th>작성일</th>
+                            <td>{{ formatDate(approvalDetail.createdAt, 'date') }}</td>
+                            <th>결재 완료일</th>
+                            <td>{{ getCompletionDate() }}</td>
+                            <th>결재 상태</th>
+                            <td>
+                                <span class="status-badge" :class="getStatusClass(approvalDetail.status)">
+                                    {{ getStatusText(approvalDetail.status) }}
+                                </span>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
 
-        <div class="content-section">
-            <table class="info-table">
-                <tbody>
-                    <tr>
-                        <th>결재 유형</th>
-                        <td>{{ approvalDetail.categoryName }}</td>
-                        <th>작성일</th>
-                        <td>{{ formatDate(approvalDetail.createdAt, 'date') }}</td>
-                        <th>결재 완료일</th>
-                        <td>{{ getCompletionDate() }}</td>
-                        <th>결재 상태</th>
-                        <td>
-                            <span class="status-badge" :class="getStatusClass(approvalDetail.status)">
-                                {{ getStatusText(approvalDetail.status) }}
-                            </span>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
-
-            <div class="approval-line-section">
-                <h3>결재선</h3>
-                <div class="approvers-list">
-                    <div 
-                        v-for="approver in approvalDetail.approvers" 
-                        :key="approver.memberId" 
-                        class="approver-item"
-                        :class="getApproverStatusClass(approver)"
-                    >
-                        <div class="signature-box">
-                            <span v-if="getApproverStatusClass(approver) === 'approved'" class="stamp approved">승인</span>
-                            <span v-else-if="getApproverStatusClass(approver) === 'rejected'" class="stamp rejected">반려</span>
-                        </div>
-                        <div class="approver-name">{{ approver.memberName }} {{ approver.positionName }}</div>
-                        <div v-if="approver.approvedAt" class="approval-date">
-                            {{ formatDate(approver.approvedAt, 'date') }}
+                <div class="approval-line-section">
+                    <h3>결재선</h3>
+                    <div class="approvers-list">
+                        <div 
+                            v-for="approver in approvalDetail.approvers" 
+                            :key="approver.memberId" 
+                            class="approver-item"
+                            :class="getApproverStatusClass(approver)"
+                        >
+                            <div class="signature-box">
+                                <span v-if="getApproverStatusClass(approver) === 'approved'" class="stamp approved">승인</span>
+                                <span v-else-if="getApproverStatusClass(approver) === 'rejected'" class="stamp rejected">반려</span>
+                            </div>
+                            <div class="approver-name">{{ approver.memberName }} {{ approver.positionName }}</div>
+                            <div v-if="approver.approvedAt" class="approval-date">
+                                {{ formatDate(approver.approvedAt, 'date') }}
+                            </div>
                         </div>
                     </div>
                 </div>
-            </div>
 
-            <div class="attachment-section">
-                <h3>첨부 문서</h3>
-                <p>첨부된 문서가 없습니다.</p>
-            </div>
+                <div class="attachment-section">
+                    <h3>첨부 문서</h3>
+                    <p>첨부된 문서가 없습니다.</p>
+                </div>
 
-            <div class="main-content">
-                <h2 class="content-title">{{ approvalDetail.categoryName }}</h2>
-                <div class="form-layout">
-                    <div class="form-row">
-                        <label>신청자</label>
-                        <span>{{ approvalDetail.writerName }} ({{ approvalDetail.writerDepartment }})</span>
-                    </div>
-                    <template v-for="item in approvalDetail.items" :key="item.itemName">
+                <div class="main-content">
+                    <h2 class="content-title">{{ approvalDetail.categoryName }}</h2>
+                    <div class="form-layout">
                         <div class="form-row">
-                            <label>{{ item.itemName }}</label>
-                            <span>{{ getItemContent(item) }}</span>
+                            <label>신청자</label>
+                            <span>{{ approvalDetail.writerName }} ({{ approvalDetail.writerDepartment }})</span>
                         </div>
-                    </template>
-                </div>
-                <div class="disclaimer">
-                    <p>※ 해당 문서는 결재 완료 후 수정이 불가능하니, 내용을 정확히 입력해 주세요.</p>
+                        <template v-for="item in approvalDetail.items" :key="item.itemName">
+                            <div class="form-row">
+                                <label>{{ item.itemName }}</label>
+                                <span>{{ getItemContent(item) }}</span>
+                            </div>
+                        </template>
+                    </div>
+                    <div class="disclaimer">
+                        <p>※ 해당 문서는 결재 완료 후 수정이 불가능하니, 내용을 정확히 입력해 주세요.</p>
+                    </div>
                 </div>
             </div>
         </div>
@@ -367,11 +372,16 @@ onUnmounted(() => {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: 1.5rem;
+    margin-bottom: 20px;
+}
+
+.header-left {
+    display: flex;
+    align-items: center;
 }
 
 .page-title {
-    font-size: 1.8rem;
+    font-size: 24px;
     font-weight: 600;
 }
 
@@ -601,5 +611,9 @@ h3 {
 
 .disclaimer p {
     margin: 0.3rem 0;
+}
+
+.cursor-pointer {
+    cursor: pointer;
 }
 </style>

--- a/src/views/employment/RecruitmentCreatePage.vue
+++ b/src/views/employment/RecruitmentCreatePage.vue
@@ -164,7 +164,7 @@ import { useRecruitmentRequestStore } from '@/stores/recruitmentRequestStore'
 
 const router = useRouter()
 const route = useRoute()
-const requestId = route.query.requestId;
+const requestId = route.query.id;
 
 const store = useRecruitmentStore()
 const recruitmentRequestStore = useRecruitmentRequestStore()
@@ -188,7 +188,7 @@ const form = ref({
     startedAt: '',
     endedAt: '',
     recruitmentProcesses: [],
-    recruitmentRequestId: route.query.id || null
+    recruitmentRequestId: requestId || null
 })
 
 // 폼 값이 바뀔 때마다 draftRecruitment에 저장
@@ -201,16 +201,29 @@ onMounted(async () => {
         Object.assign(form.value, store.draftRecruitment)
     }
 
-    const requestId = route.query.id
-
+    // 요청서 ID가 있으면 해당 요청서 정보를 로드
     if (requestId) {
         await recruitmentRequestStore.loadRecruitmentRequestDetail(requestId)
         requestDetail.value = recruitmentRequestStore.recruitmentRequestDetail
-        if (requestDetail.value?.startedAt) {
-            form.value.startedAt = requestDetail.value.startedAt.slice(0, 16)
-        }
-        if (requestDetail.value?.endedAt) {
-            form.value.endedAt = requestDetail.value.endedAt.slice(0, 16)
+        
+        // 요청서 정보를 폼에 자동으로 설정
+        if (requestDetail.value) {
+            // 제목 자동 설정
+            form.value.title = `${requestDetail.value.jobName} 채용 공고`
+            
+            // 날짜 설정
+            if (requestDetail.value.startedAt) {
+                form.value.startedAt = requestDetail.value.startedAt.slice(0, 16)
+            }
+            if (requestDetail.value.endedAt) {
+                form.value.endedAt = requestDetail.value.endedAt.slice(0, 16)
+            }
+            
+            // 요청서 ID 설정
+            form.value.recruitmentRequestId = requestId
+            
+            // 기본 채용 유형 설정
+            form.value.recruitType = 'REGULAR'
         }
     }
 })
@@ -229,12 +242,11 @@ const rules = {
 }
 
 const goToApplicationItem = () => {
-
     store.setDraftRecruitment(form.value)
 
     router.push({
         path: '/employment/application-items/select',
-        query: { requestId: route.query.id }
+        query: { requestId: requestId }
     })
 }
 


### PR DESCRIPTION
### 🪄 PR 타입
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] 버그 픽스

### 📝 변경 사항
* 채용요청 결재 완료 시 채용요청서 연동 버튼 추가

### 💬 리뷰 요구사항
* 더미데이터 수정이 필요합니다
```
-- [401] 채용 요청서
INSERT INTO `approval_category_item` (`id`,`category_id`, `name`, `input_type`) VALUES
    (40101,401, '부서', 5),
    (40102,401, '직무', 5),
    (40103,401, '모집 인원', 5),
    (40104,401, '모집 시작일', 4),
    (40105,401, '모집 마감일', 4),
    (40106,401, '지원자격', 0),
    (40107,401, '우대사항', 0),
    (40108,401, '주요업무', 0),
    (40109,401, '고용형태', 0),
    (40110,401, '근무 지역', 0);

INSERT INTO approval_line (step_order, approval_category_id, position_id) VALUES
-- 101. 결재 취소 신청서
(1, 101, 1), (2, 101, 2), (3, 101, 3),
-- 201. 인사발령 요청서
(1, 201, 1), (2, 201, 2), (3, 201, 3),
-- 202. 사직서
(1, 202, 1), (2, 202, 2), (3, 202, 3), (4, 202, 4),
-- 301. 지출 결의서
(1, 301, 1), (2, 301, 2), (3, 301, 3),
-- 302. 법인카드 신청서
(1, 302, 1), (2, 302, 2), (3, 302, 3),
-- 303. 급여 변경 요청서
(1, 303, 1), (2, 303, 2), (3, 303, 3), (4, 303, 4),
-- 304. 출장 신청서
(1, 304, 1), (2, 304, 2), (3, 304, 3),
-- 305. 물품 구매 요청서
(1, 305, 1), (2, 305, 2),
-- 401. 채용 요청서   (수정)
(1, 401, 2), (2, 401, 3),
-- 501. 휴가 신청서
(1, 501, 1), (2, 501, 2),
-- 502. 조퇴 신청서
(1, 502, 1), (2, 502, 2),
-- 601. 회의실 예약 요청서
(1, 601, 1), (2, 601, 2);
```

### 📷 관련 스크린샷
![image](https://github.com/user-attachments/assets/b17cb913-2710-46c9-b6a0-9904005a0725)
![image](https://github.com/user-attachments/assets/d96a965a-995e-49a1-9ed8-2ab727531085)
![image](https://github.com/user-attachments/assets/05068614-dc5f-454f-a45e-eeb709ca8657)

### 🧪 테스트 계획 또는 완료 사항
- [결재 작성 페이지](http://localhost:8080/approval/create)
