### PR TITLE
[fix] 발표전 오류나는 부분 수정

### DIFF
--- a/src/components/employment/JobtestQuestionDetailModal.vue
+++ b/src/components/employment/JobtestQuestionDetailModal.vue
@@ -1,102 +1,148 @@
 <template>
-  <v-dialog :model-value="modelValue" @update:modelValue="emit('update:modelValue', $event)" max-width="1200">
-    <v-card class="mb-4">
-      <v-card-text>
-        <v-row class="mt-4 px-4">
-          <h2 class="text-h6 font-weight-bold mb-4">문제 상세 정보</h2>
-          <v-spacer />
-          <v-simple-table class="info-table" den>
+  <v-dialog :model-value="modelValue" @update:modelValue="emit('update:modelValue', $event)" max-width="1000">
+    <v-card class="question-detail-modal">
+      <!-- 헤더 -->
+      <v-card-title class="modal-header">
+        <div class="header-content">
+          <h2 class="modal-title">문제 상세 정보</h2>
+          <v-btn icon @click="closeModal" class="close-btn">
+            <v-icon>mdi-close</v-icon>
+          </v-btn>
+        </div>
+      </v-card-title>
+
+      <v-card-text class="modal-content">
+        <!-- 문제 정보 -->
+        <div class="question-info-section">
+          <div class="question-content-item">
+            <span class="question-content-label">문제 내용</span>
+            <div class="question-content-text">{{ question.content }}</div>
+          </div>
+          
+          <div v-if="question.detailContent" class="info-item">
+            <span class="info-label">상세 설명:</span>
+            <span class="info-content">{{ question.detailContent }}</span>
+          </div>
+          
+          <div class="info-row">
+            <div class="info-item">
+              <span class="info-label">유형:</span>
+              <span class="info-tag type-tag">{{ getQuestionTypeLabel(question.type) }}</span>
+            </div>
+            <div class="info-item">
+              <span class="info-label">난이도:</span>
+              <span class="info-tag difficulty-tag" :class="getDifficultyClass(question.difficulty)">{{ getDifficultyLabel(question.difficulty) }}</span>
+            </div>
+          </div>
+          
+          <div v-if="question.answer" class="info-item">
+            <span class="info-label">정답:</span>
+            <span class="info-content answer-content">{{ question.answer }}</span>
+          </div>
+        </div>
+
+        <!-- 선택지 -->
+        <div v-if="question.type === 'MULTIPLE' && question.questionOptions?.length" class="options-section">
+          <h3 class="section-title">선택지</h3>
+          <div class="options-list">
+            <div v-for="(opt, i) in question.questionOptions" :key="i" 
+                 class="option-item"
+                 :class="{ 'correct-option': question.answer?.trim() === opt.content?.trim() }">
+              <span class="option-number">{{ opt.optionNumber ? `${opt.optionNumber}.` : `${i + 1}.` }}</span>
+              <span class="option-content">{{ opt.content }}</span>
+              <v-icon v-if="question.answer?.trim() === opt.content?.trim()" 
+                      color="white" 
+                      size="small" 
+                      class="correct-icon">
+                mdi-check-circle
+              </v-icon>
+            </div>
+          </div>
+        </div>
+
+        <!-- 채점 기준 -->
+        <div v-if="question.gradingCriteria?.length" class="grading-section">
+          <h3 class="section-title">채점 기준</h3>
+          <v-simple-table class="grading-table">
             <thead>
               <tr>
-                <th class="text-left">생성자</th>
-                <th class="text-left">생성일</th>
-                <th class="text-left">최종 수정자</th>
-                <th class="text-left">최종 수정일</th>
+                <th>기준 내용</th>
+                <th>가중치</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="(c, i) in question.gradingCriteria" :key="i">
+                <td>{{ c.content }}</td>
+                <td>{{ c.scoreWeight }}</td>
+              </tr>
+            </tbody>
+          </v-simple-table>
+        </div>
+
+        <!-- 사용중인 실무테스트 -->
+        <div v-if="question.usedJobTests?.length" class="used-tests-section">
+          <h3 class="section-title">이 문제를 사용하는 실무 테스트</h3>
+          <div class="tests-list">
+            <div v-for="(test, i) in question.usedJobTests" :key="i" class="test-item">
+              {{ test.title }}
+            </div>
+          </div>
+        </div>
+
+        <!-- 메타 정보 테이블 -->
+        <div class="meta-info-section">
+          <h3 class="meta-section-title">생성/수정 정보</h3>
+          <v-simple-table class="meta-table">
+            <thead>
+              <tr>
+                <th>생성자</th>
+                <th>생성일</th>
+                <th>최종 수정자</th>
+                <th>최종 수정일</th>
               </tr>
             </thead>
             <tbody>
               <tr>
-                <td>{{ question.createdMemberName }}</td>
+                <td>{{ question.createdMemberName || '-' }}</td>
                 <td>{{ formatDate(question.createdAt) }}</td>
-                <td>{{ question.updatedMemberName }}</td>
+                <td>{{ question.updatedMemberName || '-' }}</td>
                 <td>{{ formatDate(question.updatedAt) }}</td>
               </tr>
             </tbody>
           </v-simple-table>
-        </v-row>
-        <div><strong>문제 내용:</strong> {{ question.content }}</div>
-        <div v-if="question.detailContent"><strong>상세 설명:</strong> {{ question.detailContent }}</div>
-        <div>
-          <strong>유형:</strong> {{ getQuestionTypeLabel(question.type) }}
-          &nbsp;&nbsp;
-          <strong>난이도:</strong> {{ getDifficultyLabel(question.difficulty) }}
         </div>
-        <div v-if="question.answer"><strong>정답:</strong> {{ question.answer }}</div>
       </v-card-text>
 
-
-      <!-- 선지 -->
-      <v-card v-if="question.type === 'MULTIPLE' && question.questionOptions?.length" class="mb-4" variant="tonal">
-        <v-card-title>선택지</v-card-title>
-        <v-list>
-          <v-list-item v-for="(opt, i) in question.questionOptions" :key="i">
-            <v-list-item-title>
-              {{ opt.optionNumber ? `${opt.optionNumber}. ` : '' }}{{ opt.content }}
-              <span v-if="question.answer?.trim() === opt.content?.trim()" class="text-success font-weight-bold">
-                <v-icon v-if="question.answer === opt.content" color="green" size="small"
-                  class="ml-1">mdi-check-circle</v-icon>
-              </span>
-            </v-list-item-title>
-          </v-list-item>
-        </v-list>
-      </v-card>
-
-      <!-- 채점 기준 -->
-      <v-card v-if="question.gradingCriteria?.length" class="mb-4" variant="tonal">
-        <v-card-title>채점 기준</v-card-title>
-        <v-simple-table>
-          <thead>
-            <tr>
-              <th>기준 내용</th>
-              <th>가중치</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr v-for="(c, i) in question.gradingCriteria" :key="i">
-              <td>{{ c.content }}</td>
-              <td>{{ c.scoreWeight }}</td>
-            </tr>
-          </tbody>
-        </v-simple-table>
-      </v-card>
-
-      <!-- 사용중인 실무테스트 -->
-      <v-card v-if="question.usedJobTests?.length" class="mb-4" variant="tonal">
-        <v-card-title>이 문제를 사용하는 실무 테스트</v-card-title>
-        <v-list>
-          <v-list-item v-for="(test, i) in question.usedJobTests" :key="i">
-            <v-list-item-title>{{ test.title }}</v-list-item-title>
-          </v-list-item>
-        </v-list>
-      </v-card>
-
-      <!-- 생성/수정 정보 -->
-
-
-      <v-card-actions class="justify-end">
-        <v-btn text @click="closeModal">닫기</v-btn>
-        <v-btn v-if="props.showDelete" color="error" variant="outlined" prepend-icon="mdi-delete" @click="handleDeleteConfirm">
+      <!-- 액션 버튼 -->
+      <v-card-actions class="modal-actions">
+        <v-btn variant="text" @click="closeModal" class="cancel-btn">
+          닫기
+        </v-btn>
+        <v-spacer />
+        <v-btn v-if="props.showDelete" 
+               color="error" 
+               variant="outlined" 
+               prepend-icon="mdi-delete" 
+               @click="handleDeleteConfirm"
+               class="delete-btn">
           삭제하기
         </v-btn>
-        <v-btn v-if="props.showEdit" color="primary" variant="tonal" @click="goEditPage" prepend-icon="mdi-pencil">
+        <v-btn v-if="props.showEdit" 
+               color="primary" 
+               variant="elevated" 
+               @click="goEditPage" 
+               prepend-icon="mdi-pencil"
+               class="edit-btn">
           수정하기
         </v-btn>
       </v-card-actions>
     </v-card>
-    <AlertModal v-if="showDeleteConfirm" :message="'정말 이 문제를 삭제하시겠습니까? 복구할 수 없습니다.'" @confirm="confirmDelete"
-      @cancel="showDeleteConfirm = false" />
+    
+    <AlertModal v-if="showDeleteConfirm" 
+                :message="'정말 이 문제를 삭제하시겠습니까? 복구할 수 없습니다.'" 
+                @confirm="confirmDelete"
+                @cancel="showDeleteConfirm = false" />
   </v-dialog>
-
 </template>
 
 <script setup>
@@ -171,30 +217,477 @@ function formatDate(dateStr) {
   return `${yyyy}-${MM}-${dd} ${HH}:${mm}`
 }
 
+function getDifficultyClass(difficulty) {
+  switch (difficulty) {
+    case 'EASY':
+    case '쉬움':
+      return 'difficulty-easy'
+    case 'MEDIUM':
+    case '보통':
+      return 'difficulty-medium'
+    case 'HARD':
+    case '어려움':
+      return 'difficulty-hard'
+    default:
+      return 'difficulty-medium'
+  }
+}
+
 </script>
 
 <style scoped>
-.v-card {
-  border-radius: 16px;
+/* 모달 전체 스타일 */
+.question-detail-modal {
+  border-radius: 20px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.15);
+  overflow: hidden;
 }
 
-.info-table {
-  font-size: 14px;
-  color: #333;
-  margin-top: 16px;
+/* 헤더 스타일 */
+.modal-header {
+  background: linear-gradient(135deg, #4A7C59 0%, #7EDC92 100%);
+  color: white;
+  padding: 24px 32px;
+  border-bottom: none;
 }
 
-.info-table thead th {
-  color: #666;
+.header-content {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+}
+
+.modal-title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin: 0;
+  color: white;
+}
+
+.close-btn {
+  color: white !important;
+  background: rgba(255, 255, 255, 0.1) !important;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  transition: all 0.3s ease;
+}
+
+.close-btn:hover {
+  background: rgba(255, 255, 255, 0.2) !important;
+  transform: scale(1.1);
+}
+
+/* 컨텐츠 영역 */
+.modal-content {
+  padding: 32px;
+  max-height: 70vh;
+  overflow-y: auto;
+}
+
+/* 메타 정보 테이블 */
+.meta-info-section {
+  margin-top: 40px;
+  padding-top: 24px;
+  border-top: 1px solid #e9ecef;
+}
+
+.meta-section-title {
+  font-size: 1rem;
   font-weight: 600;
-  font-size: 12px;
-  border-bottom: 1px solid #ccc;
-  padding: 8px;
+  color: #6c757d;
+  margin-bottom: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
 }
 
-.info-table tbody td {
-  padding: 10px 8px;
+.meta-table {
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  background: #f8f9fa;
+}
+
+.meta-table thead th {
+  background: #e9ecef;
+  color: #6c757d;
   font-weight: 500;
-  color: #1e1e1e;
+  font-size: 0.8rem;
+  padding: 12px 8px;
+  border-bottom: 1px solid #dee2e6;
+  text-align: center;
+}
+
+.meta-table tbody td {
+  padding: 10px 8px;
+  font-weight: 400;
+  color: #6c757d;
+  text-align: center;
+  border-bottom: 1px solid #f1f3f4;
+  font-size: 0.85rem;
+}
+
+.meta-table tbody tr:hover {
+  background: #f1f3f4;
+}
+
+/* 문제 정보 섹션 */
+.question-info-section {
+  margin-bottom: 40px;
+  padding: 24px;
+  background: linear-gradient(135deg, #ffffff 0%, #f8f9fa 100%);
+  border-radius: 16px;
+  border: 1px solid #e9ecef;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+}
+
+.question-content-item {
+  margin-bottom: 32px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.question-content-label {
+  font-weight: 700;
+  color: #212529;
+  font-size: 1.1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.question-content-text {
+  color: #212529;
+  font-weight: 500;
+  line-height: 1.8;
+  font-size: 1.2rem;
+  background: #f8f9fa;
+  padding: 20px;
+  border-radius: 12px;
+  border-left: 4px solid #4A7C59;
+  width: 100%;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+}
+
+.info-item {
+  margin-bottom: 20px;
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.info-row {
+  display: flex;
+  gap: 32px;
+  margin-bottom: 20px;
+}
+
+.info-row .info-item {
+  flex: 1;
+  margin-bottom: 0;
+}
+
+.info-label {
+  font-weight: 600;
+  color: #495057;
+  min-width: 80px;
+  font-size: 0.9rem;
+}
+
+.info-content {
+  color: #212529;
+  font-weight: 500;
+  line-height: 1.6;
+  flex: 1;
+}
+
+.answer-content {
+  background: #e8f5e8;
+  padding: 8px 12px;
+  border-radius: 8px;
+  border-left: 4px solid #4CAF50;
+  font-weight: 600;
+  color: #2e7d32;
+}
+
+/* 태그 스타일 */
+.info-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 12px;
+  border-radius: 20px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  transition: all 0.3s ease;
+}
+
+.type-tag {
+  background: #4A7C59;
+  color: white;
+}
+
+.type-tag:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 8px rgba(74, 124, 89, 0.3);
+}
+
+.difficulty-tag {
+  color: white;
+}
+
+.difficulty-easy {
+  background: #4CAF50;
+}
+
+.difficulty-easy:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 8px rgba(76, 175, 80, 0.3);
+}
+
+.difficulty-medium {
+  background: #2196F3;
+}
+
+.difficulty-medium:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 8px rgba(33, 150, 243, 0.3);
+}
+
+.difficulty-hard {
+  background: #F44336;
+}
+
+.difficulty-hard:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 8px rgba(244, 67, 54, 0.3);
+}
+
+/* 섹션 제목 */
+.section-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #212529;
+  margin-bottom: 16px;
+  padding-bottom: 8px;
+  border-bottom: 2px solid #e9ecef;
+}
+
+/* 선택지 섹션 */
+.options-section {
+  margin-bottom: 32px;
+}
+
+.options-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.option-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px;
+  background: #f8f9fa;
+  border-radius: 12px;
+  border: 2px solid transparent;
+  transition: all 0.3s ease;
+}
+
+.option-item:hover {
+  background: #e9ecef;
+  border-color: #dee2e6;
+}
+
+.correct-option {
+  background: linear-gradient(135deg, #4CAF50 0%, #45a049 100%);
+  border-color: #4CAF50;
+  color: white;
+  box-shadow: 0 4px 12px rgba(76, 175, 80, 0.3);
+}
+
+.correct-option:hover {
+  background: linear-gradient(135deg, #45a049 0%, #3d8b40 100%);
+  border-color: #45a049;
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(76, 175, 80, 0.4);
+}
+
+.correct-option .option-number {
+  color: white;
+  font-weight: 700;
+}
+
+.correct-option .option-content {
+  color: white;
+  font-weight: 600;
+}
+
+.option-number {
+  font-weight: 600;
+  color: #495057;
+  min-width: 30px;
+  font-size: 0.9rem;
+}
+
+.option-content {
+  flex: 1;
+  color: #212529;
+  font-weight: 500;
+  line-height: 1.5;
+}
+
+.correct-icon {
+  color: #4CAF50 !important;
+  margin-left: auto;
+}
+
+/* 채점 기준 테이블 */
+.grading-section {
+  margin-bottom: 32px;
+}
+
+.grading-table {
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+.grading-table thead th {
+  background: #f8f9fa;
+  color: #495057;
+  font-weight: 600;
+  font-size: 0.875rem;
+  padding: 16px 12px;
+  border-bottom: 2px solid #e9ecef;
+}
+
+.grading-table tbody td {
+  padding: 16px 12px;
+  font-weight: 500;
+  color: #212529;
+  border-bottom: 1px solid #f1f3f4;
+}
+
+.grading-table tbody tr:hover {
+  background: #f8f9fa;
+}
+
+/* 사용중인 테스트 섹션 */
+.used-tests-section {
+  margin-bottom: 32px;
+}
+
+.tests-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.test-item {
+  padding: 12px 16px;
+  background: #e3f2fd;
+  border-radius: 8px;
+  color: #1976d2;
+  font-weight: 500;
+  border-left: 4px solid #2196f3;
+}
+
+/* 액션 버튼 */
+.modal-actions {
+  padding: 24px 32px;
+  background: #f8f9fa;
+  border-top: 1px solid #e9ecef;
+  gap: 12px;
+}
+
+.cancel-btn {
+  color: #6c757d !important;
+  font-weight: 500;
+  text-transform: none;
+  padding: 8px 16px;
+}
+
+.cancel-btn:hover {
+  background: #e9ecef !important;
+}
+
+.delete-btn {
+  font-weight: 500;
+  text-transform: none;
+  padding: 8px 20px;
+  border-radius: 8px;
+}
+
+.edit-btn {
+  font-weight: 500;
+  text-transform: none;
+  padding: 8px 20px;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(74, 124, 89, 0.3);
+}
+
+.edit-btn:hover {
+  box-shadow: 0 6px 16px rgba(74, 124, 89, 0.4);
+}
+
+/* 반응형 디자인 */
+@media (max-width: 768px) {
+  .modal-content {
+    padding: 20px;
+  }
+  
+  .modal-header {
+    padding: 20px;
+  }
+  
+  .modal-actions {
+    padding: 20px;
+    flex-direction: column;
+  }
+  
+  .info-row {
+    flex-direction: column;
+    gap: 16px;
+  }
+  
+  .info-item {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+  
+  .info-label {
+    min-width: auto;
+  }
+  
+  .info-tag {
+    font-size: 0.75rem;
+    padding: 4px 10px;
+  }
+}
+
+/* 스크롤바 스타일링 */
+.modal-content::-webkit-scrollbar {
+  width: 8px;
+}
+
+.modal-content::-webkit-scrollbar-track {
+  background: #f1f1f1;
+  border-radius: 4px;
+}
+
+.modal-content::-webkit-scrollbar-thumb {
+  background: #c1c1c1;
+  border-radius: 4px;
+}
+
+.modal-content::-webkit-scrollbar-thumb:hover {
+  background: #a8a8a8;
 }
 </style>

--- a/src/components/employment/JobtestQuestionDetailModal.vue
+++ b/src/components/employment/JobtestQuestionDetailModal.vue
@@ -27,11 +27,11 @@
           <div class="info-row">
             <div class="info-item">
               <span class="info-label">유형:</span>
-              <span class="info-tag type-tag" :class="getQuestionTypeClass(question.type)">{{ getQuestionTypeLabel(question.type) }}</span>
+              <span class="info-tag" :style="getQuestionTypeStyle(question.type)">{{ getQuestionTypeLabel(question.type) }}</span>
             </div>
             <div class="info-item">
               <span class="info-label">난이도:</span>
-              <span class="info-tag difficulty-tag" :class="getDifficultyClass(question.difficulty)">{{ getDifficultyLabel(question.difficulty) }}</span>
+              <span class="info-tag" :style="getDifficultyStyle(question.difficulty)">{{ getDifficultyLabel(question.difficulty) }}</span>
             </div>
           </div>
           
@@ -152,8 +152,8 @@ import { useToast } from 'vue-toastification'
 
 import { useJobtestQuestionStore } from '@/stores/jobtestQuestionStore'
 
-import { getQuestionTypeLabel, getQuestionTypeColors, getQuestionTypeClass } from '@/constants/employment/questionTypes.js'
-import { getDifficultyLabel, getDifficultyColors, getDifficultyClass } from '@/constants/employment/difficulty.js'
+import { getQuestionTypeLabel, getQuestionTypeColors } from '@/constants/employment/questionTypes.js'
+import { getDifficultyLabel, getDifficultyColors } from '@/constants/employment/difficulty.js'
 import AlertModal from '@/components/common/AlertModal.vue'
 
 const jobtestQuestionStore = useJobtestQuestionStore()
@@ -427,54 +427,9 @@ const getQuestionTypeStyle = (type) => {
   transition: all 0.3s ease;
 }
 
-.type-tag {
-  background: #4A7C59;
-  color: white;
-}
-
-.type-multiple {
-  background: #81C784;
-  color: #2E7D32;
-}
-
-.type-subjective {
-  background: #FFB74D;
-  color: #E65100;
-}
-
-.type-descriptive {
-  background: #BA68C8;
-  color: #7B1FA2;
-}
-
-.type-default {
-  background: #90A4AE;
-  color: #37474F;
-}
-
-.type-tag:hover,
-.difficulty-tag:hover {
+.info-tag:hover {
   transform: translateY(-1px);
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
-}
-
-.difficulty-tag {
-  color: white;
-}
-
-.difficulty-easy {
-  background: #A5D6A7;
-  color: #2E7D32;
-}
-
-.difficulty-medium {
-  background: #90CAF9;
-  color: #1565C0;
-}
-
-.difficulty-hard {
-  background: #EF9A9A;
-  color: #C62828;
 }
 
 /* 섹션 제목 */

--- a/src/components/employment/JobtestQuestionDetailModal.vue
+++ b/src/components/employment/JobtestQuestionDetailModal.vue
@@ -27,7 +27,7 @@
           <div class="info-row">
             <div class="info-item">
               <span class="info-label">유형:</span>
-              <span class="info-tag type-tag">{{ getQuestionTypeLabel(question.type) }}</span>
+              <span class="info-tag type-tag" :class="getQuestionTypeClass(question.type)">{{ getQuestionTypeLabel(question.type) }}</span>
             </div>
             <div class="info-item">
               <span class="info-label">난이도:</span>
@@ -152,8 +152,8 @@ import { useToast } from 'vue-toastification'
 
 import { useJobtestQuestionStore } from '@/stores/jobtestQuestionStore'
 
-import { getQuestionTypeLabel } from '@/constants/employment/questionTypes'
-import { getDifficultyLabel } from '@/constants/employment/difficulty'
+import { getQuestionTypeLabel, getQuestionTypeColors, getQuestionTypeClass } from '@/constants/employment/questionTypes.js'
+import { getDifficultyLabel, getDifficultyColors, getDifficultyClass } from '@/constants/employment/difficulty.js'
 import AlertModal from '@/components/common/AlertModal.vue'
 
 const jobtestQuestionStore = useJobtestQuestionStore()
@@ -217,21 +217,22 @@ function formatDate(dateStr) {
   return `${yyyy}-${MM}-${dd} ${HH}:${mm}`
 }
 
-function getDifficultyClass(difficulty) {
-  switch (difficulty) {
-    case 'EASY':
-    case '쉬움':
-      return 'difficulty-easy'
-    case 'MEDIUM':
-    case '보통':
-      return 'difficulty-medium'
-    case 'HARD':
-    case '어려움':
-      return 'difficulty-hard'
-    default:
-      return 'difficulty-medium'
-  }
-}
+// 난이도 및 유형 색상 정보
+const getDifficultyStyle = (difficulty) => {
+  const colors = getDifficultyColors(difficulty);
+  return {
+    backgroundColor: colors.background,
+    color: colors.text
+  };
+};
+
+const getQuestionTypeStyle = (type) => {
+  const colors = getQuestionTypeColors(type);
+  return {
+    backgroundColor: colors.background,
+    color: colors.text
+  };
+};
 
 </script>
 
@@ -431,9 +432,30 @@ function getDifficultyClass(difficulty) {
   color: white;
 }
 
-.type-tag:hover {
+.type-multiple {
+  background: #81C784;
+  color: #2E7D32;
+}
+
+.type-subjective {
+  background: #FFB74D;
+  color: #E65100;
+}
+
+.type-descriptive {
+  background: #BA68C8;
+  color: #7B1FA2;
+}
+
+.type-default {
+  background: #90A4AE;
+  color: #37474F;
+}
+
+.type-tag:hover,
+.difficulty-tag:hover {
   transform: translateY(-1px);
-  box-shadow: 0 4px 8px rgba(74, 124, 89, 0.3);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
 }
 
 .difficulty-tag {
@@ -441,30 +463,18 @@ function getDifficultyClass(difficulty) {
 }
 
 .difficulty-easy {
-  background: #4CAF50;
-}
-
-.difficulty-easy:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 4px 8px rgba(76, 175, 80, 0.3);
+  background: #A5D6A7;
+  color: #2E7D32;
 }
 
 .difficulty-medium {
-  background: #2196F3;
-}
-
-.difficulty-medium:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 4px 8px rgba(33, 150, 243, 0.3);
+  background: #90CAF9;
+  color: #1565C0;
 }
 
 .difficulty-hard {
-  background: #F44336;
-}
-
-.difficulty-hard:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 4px 8px rgba(244, 67, 54, 0.3);
+  background: #EF9A9A;
+  color: #C62828;
 }
 
 /* 섹션 제목 */

--- a/src/components/employment/JobtestQuestionList.vue
+++ b/src/components/employment/JobtestQuestionList.vue
@@ -15,7 +15,11 @@
                     <td>{{ index + 1 }}</td>
                     <td>{{ question.content }}</td>
                     <td>{{ question.score }}점</td>
-                    <td>{{ difficultyLabel(question.difficulty) }}</td>
+                    <td>
+                        <span class="difficulty-tag" :style="getDifficultyStyle(question.difficulty)">
+                            {{ getDifficultyLabel(question.difficulty) }}
+                        </span>
+                    </td>
                 </tr>
             </tbody>
         </v-table>
@@ -23,16 +27,27 @@
 </template>
 
 <script setup>
+import { getDifficultyLabel, getDifficultyColors } from '@/constants/employment/difficulty.js'
+
 defineProps({
     questions: Array
 })
 
-const difficultyLabel = (level) => {
-    switch (level) {
-        case 'EASY': return '쉬움'
-        case 'MEDIUM': return '보통'
-        case 'HARD': return '어려움'
-        default: return '알 수 없음'
-    }
-}
+const getDifficultyStyle = (difficulty) => {
+    const colors = getDifficultyColors(difficulty);
+    return {
+        backgroundColor: colors.background,
+        color: colors.text,
+        padding: '4px 8px',
+        borderRadius: '12px',
+        fontSize: '0.75rem',
+        fontWeight: '600',
+        textTransform: 'uppercase',
+        letterSpacing: '0.3px',
+        boxShadow: '0 1px 3px rgba(0, 0, 0, 0.1)',
+        transition: 'all 0.2s ease',
+        display: 'inline-flex',
+        alignItems: 'center'
+    };
+};
 </script>

--- a/src/components/employment/JobtestQuestionList.vue
+++ b/src/components/employment/JobtestQuestionList.vue
@@ -7,16 +7,22 @@
                     <th>번호</th>
                     <th>내용</th>
                     <th>배점</th>
+                    <th>유형</th>
                     <th>난이도</th>
                 </tr>
             </thead>
             <tbody>
-                <tr v-for="(question, index) in questions" :key="question.id">
+                <tr v-for="(question, index) in validQuestions" :key="question.id">
                     <td>{{ index + 1 }}</td>
                     <td>{{ question.content }}</td>
                     <td>{{ question.score }}점</td>
                     <td>
-                        <span class="difficulty-tag" :style="getDifficultyStyle(question.difficulty)">
+                        <span :style="getQuestionTypeStyle(question.type)">
+                            {{ getQuestionTypeLabel(question.type) }}
+                        </span>
+                    </td>
+                    <td>
+                        <span :style="getDifficultyStyle(question.difficulty)">
                             {{ getDifficultyLabel(question.difficulty) }}
                         </span>
                     </td>
@@ -27,11 +33,35 @@
 </template>
 
 <script setup>
+import { computed } from 'vue'
 import { getDifficultyLabel, getDifficultyColors } from '@/constants/employment/difficulty.js'
+import { getQuestionTypeLabel, getQuestionTypeColors } from '@/constants/employment/questionTypes.js'
 
-defineProps({
+const props = defineProps({
     questions: Array
 })
+
+const validQuestions = computed(() => {
+    return (props.questions || []).filter(q => q);
+});
+
+const getQuestionTypeStyle = (type) => {
+    const colors = getQuestionTypeColors(type);
+    return {
+        backgroundColor: colors.background,
+        color: colors.text,
+        padding: '4px 8px',
+        borderRadius: '12px',
+        fontSize: '0.75rem',
+        fontWeight: '600',
+        textTransform: 'uppercase',
+        letterSpacing: '0.3px',
+        boxShadow: '0 1px 3px rgba(0, 0, 0, 0.1)',
+        transition: 'all 0.2s ease',
+        display: 'inline-flex',
+        alignItems: 'center'
+    };
+};
 
 const getDifficultyStyle = (difficulty) => {
     const colors = getDifficultyColors(difficulty);

--- a/src/components/employment/JobtestSelectModal.vue
+++ b/src/components/employment/JobtestSelectModal.vue
@@ -1,13 +1,43 @@
 <template>
-<v-dialog :model-value="modelValue" @update:modelValue="emit('update:modelValue', $event)" max-width="1200">
-        <v-card>
-            <v-card-title>실무 테스트 선택</v-card-title>
-            <v-card-text>
-                <v-list>
-                    <v-list-item v-for="jobtest in jobtests" :key="jobtest.id" @click="select(jobtest)">
-                        <v-list-item-title>{{ jobtest.title }}</v-list-item-title>
-                    </v-list-item>
-                </v-list>
+    <v-dialog :model-value="modelValue" @update:modelValue="emit('update:modelValue', $event)" max-width="1200">
+        <v-card class="select-modal-card">
+            <div class="modal-header">
+                <v-card-title class="modal-title">
+                    <v-icon class="title-icon">mdi-format-list-bulleted</v-icon>
+                    실무 테스트 선택
+                </v-card-title>
+                <p class="modal-description">사용할 실무 테스트를 선택해주세요.</p>
+            </div>
+            
+            <v-card-text class="modal-content">
+                <div class="jobtest-list">
+                    <div 
+                        v-for="jobtest in jobtests" 
+                        :key="jobtest.id" 
+                        class="jobtest-item"
+                        @click="select(jobtest)"
+                    >
+                        <div class="jobtest-info">
+                            <div class="jobtest-title">{{ jobtest.title }}</div>
+                            <div class="jobtest-meta">
+                                <span class="meta-item">
+                                    <v-icon class="meta-icon">mdi-clock-outline</v-icon>
+                                    {{ jobtest.testTime }}분
+                                </span>
+                                <span class="meta-item">
+                                    <v-icon class="meta-icon">mdi-trending-up</v-icon>
+                                    {{ getDifficultyLabel(jobtest.difficulty) }}
+                                </span>
+                            </div>
+                        </div>
+                        <v-icon class="select-icon">mdi-chevron-right</v-icon>
+                    </div>
+                </div>
+                
+                <div v-if="jobtests.length === 0" class="empty-state">
+                    <v-icon class="empty-icon">mdi-inbox-outline</v-icon>
+                    <p class="empty-text">등록된 실무 테스트가 없습니다.</p>
+                </div>
             </v-card-text>
         </v-card>
     </v-dialog>
@@ -15,6 +45,7 @@
 
 <script setup>
 import { defineProps, defineEmits } from 'vue'
+import { getDifficultyLabel } from '@/constants/employment/difficulty.js'
 
 const props = defineProps({
     modelValue: Boolean,
@@ -27,3 +58,169 @@ const select = (jobtest) => {
     emit('update:modelValue', false);
 };
 </script>
+
+<style scoped>
+.select-modal-card {
+    border-radius: 16px;
+    overflow: hidden;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+}
+
+/* 모달 헤더 */
+.modal-header {
+    background: linear-gradient(135deg, #1976d2, #42a5f5);
+    color: white;
+    padding: 24px;
+    text-align: center;
+}
+
+.modal-title {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin-bottom: 8px;
+}
+
+.title-icon {
+    font-size: 1.8rem;
+}
+
+.modal-description {
+    margin: 0;
+    opacity: 0.9;
+    font-size: 0.95rem;
+}
+
+/* 모달 콘텐츠 */
+.modal-content {
+    padding: 24px;
+    max-height: 60vh;
+    overflow-y: auto;
+}
+
+.jobtest-list {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.jobtest-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px;
+    border: 1px solid #e0e0e0;
+    border-radius: 12px;
+    background: white;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.jobtest-item:hover {
+    border-color: #1976d2;
+    background: #f8f9fa;
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(25, 118, 210, 0.15);
+}
+
+.jobtest-info {
+    flex: 1;
+}
+
+.jobtest-title {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: #1a237e;
+    margin-bottom: 8px;
+    line-height: 1.3;
+}
+
+.jobtest-meta {
+    display: flex;
+    gap: 16px;
+}
+
+.meta-item {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 0.85rem;
+    color: #666;
+}
+
+.meta-icon {
+    font-size: 1rem;
+    color: #1976d2;
+}
+
+.select-icon {
+    color: #1976d2;
+    font-size: 1.2rem;
+    transition: transform 0.2s ease;
+}
+
+.jobtest-item:hover .select-icon {
+    transform: translateX(4px);
+}
+
+/* 빈 상태 */
+.empty-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 48px 24px;
+    text-align: center;
+    color: #666;
+}
+
+.empty-icon {
+    font-size: 3rem;
+    color: #ccc;
+    margin-bottom: 16px;
+}
+
+.empty-text {
+    font-size: 1rem;
+    margin: 0;
+}
+
+/* 반응형 디자인 */
+@media (max-width: 600px) {
+    .modal-header {
+        padding: 20px;
+    }
+    
+    .modal-title {
+        font-size: 1.3rem;
+    }
+    
+    .title-icon {
+        font-size: 1.5rem;
+    }
+    
+    .modal-content {
+        padding: 16px;
+    }
+    
+    .jobtest-item {
+        padding: 12px;
+    }
+    
+    .jobtest-title {
+        font-size: 1rem;
+    }
+    
+    .jobtest-meta {
+        flex-direction: column;
+        gap: 4px;
+    }
+    
+    .meta-item {
+        font-size: 0.8rem;
+    }
+}
+</style>

--- a/src/components/employment/JobtestSummaryCard.vue
+++ b/src/components/employment/JobtestSummaryCard.vue
@@ -3,7 +3,12 @@
         <div class="d-flex justify-space-between">
             <div>
                 <div class="text-h6 font-weight-bold mb-2">{{ jobtest.title }}</div>
-                <div class="text-subtitle-2">난이도: {{ difficultyLabel }}</div>
+                <div class="text-subtitle-2">
+                    난이도: 
+                    <span class="difficulty-tag" :style="getDifficultyStyle(jobtest.difficulty)">
+                        {{ getDifficultyLabel(jobtest.difficulty) }}
+                    </span>
+                </div>
                 <div class="text-subtitle-2">시험 시간: {{ jobtest.testTime }}분</div>
                 <div class="text-subtitle-2">시작: {{ formatDate(jobtest.startedAt) }}</div>
                 <div class="text-subtitle-2">종료: {{ formatDate(jobtest.endedAt) }}</div>
@@ -18,19 +23,29 @@
 
 <script setup>
 import { computed } from 'vue'
+import { getDifficultyLabel, getDifficultyColors } from '@/constants/employment/difficulty.js'
 
 const props = defineProps({
     jobtest: Object
 })
 
-const difficultyLabel = computed(() => {
-    switch (props.jobtest.difficulty) {
-        case 'EASY': return '쉬움'
-        case 'MEDIUM': return '보통'
-        case 'HARD': return '어려움'
-        default: return '알 수 없음'
-    }
-})
+const getDifficultyStyle = (difficulty) => {
+    const colors = getDifficultyColors(difficulty);
+    return {
+        backgroundColor: colors.background,
+        color: colors.text,
+        padding: '4px 8px',
+        borderRadius: '12px',
+        fontSize: '0.75rem',
+        fontWeight: '600',
+        textTransform: 'uppercase',
+        letterSpacing: '0.3px',
+        boxShadow: '0 1px 3px rgba(0, 0, 0, 0.1)',
+        transition: 'all 0.2s ease',
+        display: 'inline-flex',
+        alignItems: 'center'
+    };
+};
 
 const formatDate = (dateStr) => {
     if (!dateStr) return '-'

--- a/src/components/employment/JobtestSummaryCard.vue
+++ b/src/components/employment/JobtestSummaryCard.vue
@@ -1,21 +1,53 @@
 <template>
-    <v-card variant="outlined" class="pa-4 mb-4">
-        <div class="d-flex justify-space-between">
-            <div>
-                <div class="text-h6 font-weight-bold mb-2">{{ jobtest.title }}</div>
-                <div class="text-subtitle-2">
-                    난이도: 
+    <v-card variant="outlined" class="summary-card pa-6 mb-4">
+        <div class="card-header">
+            <div class="title-section">
+                <h3 class="card-title">{{ jobtest.title }}</h3>
+                <div class="difficulty-section">
+                    <span class="difficulty-label">난이도:</span>
                     <span class="difficulty-tag" :style="getDifficultyStyle(jobtest.difficulty)">
                         {{ getDifficultyLabel(jobtest.difficulty) }}
                     </span>
                 </div>
-                <div class="text-subtitle-2">시험 시간: {{ jobtest.testTime }}분</div>
-                <div class="text-subtitle-2">시작: {{ formatDate(jobtest.startedAt) }}</div>
-                <div class="text-subtitle-2">종료: {{ formatDate(jobtest.endedAt) }}</div>
             </div>
-            <div class="text-right">
-                <div class="text-subtitle-2">생성자: {{ jobtest.createdName }} ({{ formatDate(jobtest.createdAt) }})</div>
-                <div class="text-subtitle-2">수정자: {{ jobtest.updatedName }} ({{ formatDate(jobtest.updatedAt) }})</div>
+            <div class="test-time-badge">
+                <v-icon class="time-icon">mdi-clock-outline</v-icon>
+                <span class="time-text">{{ jobtest.testTime }}분</span>
+            </div>
+        </div>
+
+        <v-divider class="my-4"></v-divider>
+
+        <div class="card-content">
+            <div class="info-grid">
+                <div class="info-item">
+                    <div class="info-label">
+                        <v-icon class="info-icon">mdi-calendar-start</v-icon>
+                        시작일시
+                    </div>
+                    <div class="info-value">{{ formatDate(jobtest.startedAt) }}</div>
+                </div>
+                <div class="info-item">
+                    <div class="info-label">
+                        <v-icon class="info-icon">mdi-calendar-end</v-icon>
+                        종료일시
+                    </div>
+                    <div class="info-value">{{ formatDate(jobtest.endedAt) }}</div>
+                </div>
+                <div class="info-item">
+                    <div class="info-label">
+                        <v-icon class="info-icon">mdi-account-plus</v-icon>
+                        생성자
+                    </div>
+                    <div class="info-value">{{ jobtest.createdName }} ({{ formatDate(jobtest.createdAt) }})</div>
+                </div>
+                <div class="info-item">
+                    <div class="info-label">
+                        <v-icon class="info-icon">mdi-account-edit</v-icon>
+                        수정자
+                    </div>
+                    <div class="info-value">{{ jobtest.updatedName }} ({{ formatDate(jobtest.updatedAt) }})</div>
+                </div>
             </div>
         </div>
     </v-card>
@@ -34,16 +66,17 @@ const getDifficultyStyle = (difficulty) => {
     return {
         backgroundColor: colors.background,
         color: colors.text,
-        padding: '4px 8px',
-        borderRadius: '12px',
+        padding: '6px 12px',
+        borderRadius: '20px',
         fontSize: '0.75rem',
         fontWeight: '600',
         textTransform: 'uppercase',
-        letterSpacing: '0.3px',
-        boxShadow: '0 1px 3px rgba(0, 0, 0, 0.1)',
+        letterSpacing: '0.5px',
+        boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)',
         transition: 'all 0.2s ease',
         display: 'inline-flex',
-        alignItems: 'center'
+        alignItems: 'center',
+        border: '1px solid rgba(255, 255, 255, 0.2)'
     };
 };
 
@@ -53,3 +86,186 @@ const formatDate = (dateStr) => {
     return `${date.toLocaleDateString()} ${date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`
 }
 </script>
+
+<style scoped>
+.summary-card {
+    background: white;
+    border-radius: 16px;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+    transition: all 0.3s ease;
+    border: 1px solid rgba(0, 0, 0, 0.05);
+    overflow: hidden;
+    position: relative;
+}
+
+.summary-card::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 4px;
+    background: linear-gradient(90deg, #1976d2, #42a5f5);
+    border-radius: 16px 16px 0 0;
+}
+
+.summary-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+}
+
+.card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 16px;
+}
+
+.title-section {
+    flex: 1;
+}
+
+.card-title {
+    color: #1a237e;
+    font-size: 1.5rem;
+    font-weight: 700;
+    margin-bottom: 12px;
+    line-height: 1.3;
+}
+
+.difficulty-section {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.difficulty-label {
+    color: #666;
+    font-size: 0.875rem;
+    font-weight: 500;
+}
+
+.difficulty-tag:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}
+
+.test-time-badge {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    background: linear-gradient(135deg, #4caf50, #66bb6a);
+    color: white;
+    padding: 8px 16px;
+    border-radius: 20px;
+    font-weight: 600;
+    font-size: 0.875rem;
+    box-shadow: 0 2px 8px rgba(76, 175, 80, 0.3);
+    transition: all 0.2s ease;
+}
+
+.test-time-badge:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(76, 175, 80, 0.4);
+}
+
+.time-icon {
+    font-size: 1rem;
+}
+
+.time-text {
+    font-weight: 600;
+}
+
+.card-content {
+    margin-top: 8px;
+}
+
+.info-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 20px;
+}
+
+.info-item {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.info-label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: #666;
+    font-size: 0.875rem;
+    font-weight: 500;
+}
+
+.info-icon {
+    color: #1976d2;
+    font-size: 1rem;
+}
+
+.info-value {
+    color: #333;
+    font-weight: 500;
+    font-size: 0.9rem;
+    padding-left: 24px;
+    line-height: 1.4;
+}
+
+/* 반응형 디자인 */
+@media (max-width: 960px) {
+    .summary-card {
+        border-radius: 12px;
+        padding: 20px;
+    }
+    
+    .card-header {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 12px;
+    }
+    
+    .test-time-badge {
+        align-self: flex-start;
+    }
+    
+    .info-grid {
+        grid-template-columns: 1fr;
+        gap: 16px;
+    }
+    
+    .card-title {
+        font-size: 1.3rem;
+    }
+}
+
+@media (max-width: 600px) {
+    .summary-card {
+        border-radius: 8px;
+        padding: 16px;
+    }
+    
+    .card-title {
+        font-size: 1.2rem;
+        margin-bottom: 8px;
+    }
+    
+    .difficulty-section {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 4px;
+    }
+    
+    .info-item {
+        gap: 4px;
+    }
+    
+    .info-value {
+        padding-left: 20px;
+        font-size: 0.85rem;
+    }
+}
+</style>

--- a/src/components/employment/MultipleChoice.vue
+++ b/src/components/employment/MultipleChoice.vue
@@ -7,16 +7,25 @@
       :class="{ selected: answer === idx }"
       @click="$emit('select', idx)"
     >
-      {{ opt.content }}
+      <div class="option-content">
+        <div class="option-number">{{ String.fromCharCode(65 + idx) }}.</div>
+        <div class="option-text">{{ opt.content }}</div>
+      </div>
+      <div class="option-indicator">
+        <v-icon v-if="answer === idx" class="check-icon">mdi-check-circle</v-icon>
+        <div v-else class="radio-circle"></div>
+      </div>
     </div>
   </div>
 </template>
+
 <script setup>
 defineProps({
   options: Array,
   answer: [Number, String, null]
 })
 </script>
+
 <style scoped>
 .multiple-choice-list {
   display: flex;
@@ -24,22 +33,163 @@ defineProps({
   gap: 12px;
   margin: 16px 0;
 }
+
 .multiple-choice-option {
-  padding: 14px 18px;
-  border: 1.5px solid #d1d5db;
-  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border: 2px solid #e0e0e0;
+  border-radius: 12px;
   background: #fff;
   cursor: pointer;
-  font-size: 1.1rem;
-  transition: background 0.2s, border 0.2s, color 0.2s;
+  font-size: 1rem;
+  transition: all 0.2s ease;
+  position: relative;
+  overflow: hidden;
 }
+
+.multiple-choice-option::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: linear-gradient(135deg, rgba(25, 118, 210, 0.05), rgba(66, 165, 245, 0.05));
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
 .multiple-choice-option:hover {
-  background: #f0f4f8;
-  border-color: #4a7c59;
+  border-color: #1976d2;
+  background: #f8f9fa;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(25, 118, 210, 0.15);
 }
+
+.multiple-choice-option:hover::before {
+  opacity: 1;
+}
+
 .multiple-choice-option.selected {
-  background: #4a7c59;
+  border-color: #1976d2;
+  background: linear-gradient(135deg, #1976d2, #42a5f5);
   color: #fff;
-  border-color: #4a7c59;
+  transform: translateY(-2px);
+  box-shadow: 0 6px 16px rgba(25, 118, 210, 0.3);
+}
+
+.multiple-choice-option.selected::before {
+  opacity: 0;
+}
+
+.option-content {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  flex: 1;
+  z-index: 1;
+  position: relative;
+}
+
+.option-number {
+  font-weight: 600;
+  font-size: 1.1rem;
+  color: #1976d2;
+  min-width: 20px;
+  text-align: center;
+  margin-top: 2px;
+}
+
+.multiple-choice-option.selected .option-number {
+  color: #fff;
+}
+
+.option-text {
+  line-height: 1.5;
+  flex: 1;
+}
+
+.option-indicator {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  z-index: 1;
+  position: relative;
+}
+
+.check-icon {
+  color: #fff;
+  font-size: 1.2rem;
+}
+
+.radio-circle {
+  width: 20px;
+  height: 20px;
+  border: 2px solid #ccc;
+  border-radius: 50%;
+  background: #fff;
+  transition: all 0.2s ease;
+}
+
+.multiple-choice-option:hover .radio-circle {
+  border-color: #1976d2;
+  background: #f0f8ff;
+}
+
+/* 애니메이션 효과 */
+.multiple-choice-option {
+  animation: fadeInUp 0.3s ease forwards;
+}
+
+.multiple-choice-option:nth-child(1) { animation-delay: 0.1s; }
+.multiple-choice-option:nth-child(2) { animation-delay: 0.2s; }
+.multiple-choice-option:nth-child(3) { animation-delay: 0.3s; }
+.multiple-choice-option:nth-child(4) { animation-delay: 0.4s; }
+.multiple-choice-option:nth-child(5) { animation-delay: 0.5s; }
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* 반응형 디자인 */
+@media (max-width: 600px) {
+  .multiple-choice-list {
+    gap: 10px;
+    margin: 12px 0;
+  }
+  
+  .multiple-choice-option {
+    padding: 14px 16px;
+    font-size: 0.95rem;
+  }
+  
+  .option-number {
+    font-size: 1rem;
+    min-width: 18px;
+  }
+  
+  .option-content {
+    gap: 10px;
+  }
+  
+  .check-icon {
+    font-size: 1.1rem;
+  }
+  
+  .radio-circle {
+    width: 18px;
+    height: 18px;
+  }
 }
 </style>

--- a/src/components/employment/MultipleQuestionForm.vue
+++ b/src/components/employment/MultipleQuestionForm.vue
@@ -1,35 +1,78 @@
 <template>
-    <div>
+    <div class="multiple-question-form">
         <!-- 문제 본문 입력 -->
-        <v-textarea label="문제를 입력해주세요." v-model="form.content" auto-grow :error-messages="errors.content" />
-
+        <div class="form-section">
+            <div class="form-label">
+                <v-icon class="label-icon">mdi-help-circle</v-icon>
+                문제 내용
+            </div>
+            <v-textarea 
+                label="문제를 입력해주세요." 
+                v-model="form.content" 
+                auto-grow 
+                :error-messages="errors.content"
+                variant="outlined"
+                rows="4"
+                class="question-textarea"
+                prepend-inner-icon="mdi-text-box-outline"
+            />
+        </div>
 
         <!-- 보기 입력 + 정답 선택 -->
-        <div class="mt-4">
-            <div class="text-subtitle-1 mb-2">보기</div>
-            <div v-for="(option, idx) in form.questionOptions" :key="idx" class="d-flex align-center mb-2">
-
-                <!-- 정답 선택 버튼 -->
-                <v-btn icon :color="option.isAnswer ? 'success' : 'grey'" variant="tonal" class="mr-2"
-                    @click="selectAnswer(idx)">
-                    <v-icon>{{ option.isAnswer ? 'mdi-check-circle' : 'mdi-circle-outline' }}</v-icon>
-                </v-btn>
-
-                <!-- 보기 내용 입력 -->
-                <v-text-field v-model="option.content" :label="`보기 ${idx + 1}`" class="flex-grow-1 mr-2"
-                    :error-messages="errors.questionOptions" />
-
-                <!-- 보기 삭제 버튼 -->
-                <v-btn icon="mdi-close" variant="text" color="error" @click="removeOption(idx)"
-                    :disabled="form.questionOptions.length <= 1" />
+        <div class="form-section">
+            <div class="form-label">
+                <v-icon class="label-icon">mdi-format-list-bulleted</v-icon>
+                보기
             </div>
+            <div class="options-container">
+                <div v-for="(option, idx) in form.questionOptions" :key="idx" class="option-item">
+                    <!-- 정답 선택 버튼 -->
+                    <v-btn 
+                        icon 
+                        :color="option.isAnswer ? 'success' : 'grey'" 
+                        variant="tonal" 
+                        class="answer-btn"
+                        @click="selectAnswer(idx)"
+                    >
+                        <v-icon>{{ option.isAnswer ? 'mdi-check-circle' : 'mdi-circle-outline' }}</v-icon>
+                    </v-btn>
 
-            <!-- 보기 추가 버튼 -->
-            <v-btn variant="outlined" class="mt-2" @click="addOption" :disabled="form.questionOptions.length >= 5">
-                + 항목 추가하기
-            </v-btn>
-            <div v-if="form.questionOptions.length >= 5" class="text-caption text-error">
-                최대 5개의 보기만 추가할 수 있습니다.
+                    <!-- 보기 내용 입력 -->
+                    <v-text-field 
+                        v-model="option.content" 
+                        :label="`보기 ${idx + 1}`" 
+                        class="option-input"
+                        :error-messages="errors.questionOptions"
+                        variant="outlined"
+                        prepend-inner-icon="mdi-format-list-numbered"
+                    />
+
+                    <!-- 보기 삭제 버튼 -->
+                    <v-btn 
+                        icon="mdi-close" 
+                        variant="text" 
+                        color="error" 
+                        class="remove-btn"
+                        @click="removeOption(idx)"
+                        :disabled="form.questionOptions.length <= 1" 
+                    />
+                </div>
+
+                <!-- 보기 추가 버튼 -->
+                <div class="add-option-section">
+                    <v-btn 
+                        variant="outlined" 
+                        class="add-option-btn" 
+                        @click="addOption" 
+                        :disabled="form.questionOptions.length >= 5"
+                        prepend-icon="mdi-plus"
+                    >
+                        항목 추가하기
+                    </v-btn>
+                    <div v-if="form.questionOptions.length >= 5" class="max-options-warning">
+                        최대 5개의 보기만 추가할 수 있습니다.
+                    </div>
+                </div>
             </div>
         </div>
     </div>
@@ -88,3 +131,160 @@ watch(() => props.form.answer, () => {
     initializeCorrectOption()
 })
 </script>
+
+<style scoped>
+.multiple-question-form {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.form-section {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.form-label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.95rem;
+    font-weight: 500;
+    color: #555;
+}
+
+.label-icon {
+    color: #1976d2;
+    font-size: 1rem;
+}
+
+.question-textarea {
+    border-radius: 8px;
+}
+
+.question-textarea :deep(.v-field) {
+    border-radius: 8px;
+    transition: all 0.2s ease;
+}
+
+.question-textarea :deep(.v-field:hover) {
+    box-shadow: 0 2px 8px rgba(25, 118, 210, 0.1);
+}
+
+/* 보기 섹션 */
+.options-container {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.option-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px;
+    border: 1px solid #e0e0e0;
+    border-radius: 12px;
+    background: #fafbfc;
+    transition: all 0.2s ease;
+}
+
+.option-item:hover {
+    border-color: #1976d2;
+    background: #f8f9fa;
+    box-shadow: 0 2px 8px rgba(25, 118, 210, 0.1);
+}
+
+.answer-btn {
+    flex-shrink: 0;
+    transition: all 0.2s ease;
+}
+
+.answer-btn:hover {
+    transform: scale(1.1);
+}
+
+.option-input {
+    flex: 1;
+    border-radius: 8px;
+}
+
+.option-input :deep(.v-field) {
+    border-radius: 8px;
+    transition: all 0.2s ease;
+}
+
+.option-input :deep(.v-field:hover) {
+    box-shadow: 0 2px 8px rgba(25, 118, 210, 0.1);
+}
+
+.remove-btn {
+    flex-shrink: 0;
+    transition: all 0.2s ease;
+}
+
+.remove-btn:hover {
+    transform: scale(1.1);
+}
+
+/* 보기 추가 섹션 */
+.add-option-section {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-top: 8px;
+}
+
+.add-option-btn {
+    align-self: flex-start;
+    border-radius: 8px;
+    transition: all 0.2s ease;
+}
+
+.add-option-btn:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(25, 118, 210, 0.2);
+}
+
+.max-options-warning {
+    color: #f44336;
+    font-size: 0.8rem;
+    font-weight: 500;
+    padding-left: 8px;
+}
+
+/* 반응형 디자인 */
+@media (max-width: 600px) {
+    .multiple-question-form {
+        gap: 20px;
+    }
+    
+    .form-label {
+        font-size: 0.9rem;
+    }
+    
+    .label-icon {
+        font-size: 0.9rem;
+    }
+    
+    .option-item {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 8px;
+        padding: 16px;
+    }
+    
+    .answer-btn {
+        align-self: flex-start;
+    }
+    
+    .remove-btn {
+        align-self: flex-end;
+    }
+    
+    .add-option-btn {
+        align-self: stretch;
+    }
+}
+</style>

--- a/src/components/employment/QuestionCreateModal.vue
+++ b/src/components/employment/QuestionCreateModal.vue
@@ -1,20 +1,65 @@
 <template>
-    <v-card-text>
-        <h2 class="text-h6 font-weight-bold mb-4">문제 등록</h2>
+    <v-card-text class="modal-content">
+        <div class="modal-header">
+            <h2 class="modal-title">문제 등록</h2>
+            <v-icon class="modal-icon">mdi-plus-circle</v-icon>
+        </div>
 
-        <v-tabs v-model="activeTab">
-            <v-tab value="MULTIPLE">선택형</v-tab>
-            <v-tab value="SUBJECTIVE">단답형</v-tab>
-            <!-- <v-tab value="DESCRIPTIVE">서술형</v-tab> -->
-        </v-tabs>
+        <!-- 문제 유형 탭 -->
+        <div class="tab-section">
+            <v-tabs v-model="activeTab" class="question-tabs">
+                <v-tab value="MULTIPLE" class="tab-item">
+                    <v-icon class="tab-icon">mdi-format-list-bulleted</v-icon>
+                    선택형
+                </v-tab>
+                <v-tab value="SUBJECTIVE" class="tab-item">
+                    <v-icon class="tab-icon">mdi-text-box-outline</v-icon>
+                    단답형
+                </v-tab>
+                <!-- <v-tab value="DESCRIPTIVE">서술형</v-tab> -->
+            </v-tabs>
+        </div>
 
-        <v-select v-model="form.difficulty" :items="difficultyOptions" label="난이도" variant="outlined" class="mt-4" />
+        <!-- 난이도 선택 -->
+        <div class="difficulty-section">
+            <div class="form-label">
+                <v-icon class="label-icon">mdi-trending-up</v-icon>
+                난이도
+            </div>
+            <v-select 
+                v-model="form.difficulty" 
+                :items="difficultyOptions" 
+                label="난이도를 선택해주세요" 
+                variant="outlined" 
+                class="difficulty-select"
+                prepend-inner-icon="mdi-trending-up"
+            />
+        </div>
 
-        <component :is="currentComponent" v-model:form="form" />
+        <!-- 문제 유형별 입력 폼 -->
+        <div class="component-section">
+            <component :is="currentComponent" v-model:form="form" />
+        </div>
 
-        <div class="d-flex justify-end mt-6">
-            <v-btn variant="tonal" @click="close">취소하기</v-btn>
-            <v-btn color="primary" class="ml-2" @click="handleSubmit">등록하기</v-btn>
+        <!-- 액션 버튼 -->
+        <div class="action-buttons">
+            <v-btn 
+                variant="tonal" 
+                color="grey" 
+                class="cancel-btn" 
+                @click="close"
+                prepend-icon="mdi-close"
+            >
+                취소하기
+            </v-btn>
+            <v-btn 
+                color="primary" 
+                class="submit-btn" 
+                @click="handleSubmit"
+                prepend-icon="mdi-check"
+            >
+                등록하기
+            </v-btn>
         </div>
     </v-card-text>
 </template>
@@ -125,3 +170,175 @@ onMounted(async () => {
     form.value.createdMemberId = memberId
 })
 </script>
+
+<style scoped>
+.modal-content {
+    padding: 24px;
+}
+
+/* 모달 헤더 */
+.modal-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 24px;
+    padding-bottom: 16px;
+    border-bottom: 1px solid #e0e0e0;
+}
+
+.modal-title {
+    color: #1a237e;
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin: 0;
+}
+
+.modal-icon {
+    color: #1976d2;
+    font-size: 1.5rem;
+}
+
+/* 탭 섹션 */
+.tab-section {
+    margin-bottom: 24px;
+}
+
+.question-tabs {
+    border-radius: 12px;
+    overflow: hidden;
+}
+
+.question-tabs :deep(.v-tab) {
+    font-weight: 500;
+    text-transform: none;
+    letter-spacing: normal;
+    min-height: 48px;
+    transition: all 0.2s ease;
+}
+
+.question-tabs :deep(.v-tab:hover) {
+    background-color: rgba(25, 118, 210, 0.04);
+}
+
+.question-tabs :deep(.v-tab--selected) {
+    background-color: rgba(25, 118, 210, 0.08);
+    color: #1976d2;
+    font-weight: 600;
+}
+
+.tab-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.tab-icon {
+    font-size: 1.1rem;
+}
+
+/* 난이도 섹션 */
+.difficulty-section {
+    margin-bottom: 24px;
+}
+
+.form-label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.95rem;
+    font-weight: 500;
+    margin-bottom: 8px;
+    color: #555;
+}
+
+.label-icon {
+    color: #1976d2;
+    font-size: 1rem;
+}
+
+.difficulty-select {
+    max-width: 300px;
+}
+
+.difficulty-select :deep(.v-field) {
+    border-radius: 8px;
+    transition: all 0.2s ease;
+}
+
+.difficulty-select :deep(.v-field:hover) {
+    box-shadow: 0 2px 8px rgba(25, 118, 210, 0.1);
+}
+
+/* 컴포넌트 섹션 */
+.component-section {
+    margin-bottom: 24px;
+}
+
+/* 액션 버튼 */
+.action-buttons {
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+    padding-top: 16px;
+    border-top: 1px solid #e0e0e0;
+}
+
+.cancel-btn,
+.submit-btn {
+    min-width: 100px;
+    border-radius: 8px;
+    font-weight: 500;
+    transition: all 0.2s ease;
+}
+
+.cancel-btn:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.submit-btn:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(25, 118, 210, 0.3);
+}
+
+/* 반응형 디자인 */
+@media (max-width: 600px) {
+    .modal-content {
+        padding: 16px;
+    }
+    
+    .modal-title {
+        font-size: 1.1rem;
+    }
+    
+    .modal-header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 8px;
+    }
+    
+    .action-buttons {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 8px;
+    }
+    
+    .cancel-btn,
+    .submit-btn {
+        min-width: auto;
+    }
+    
+    .difficulty-select {
+        max-width: none;
+    }
+    
+    .question-tabs :deep(.v-tab) {
+        min-height: 40px;
+        font-size: 0.9rem;
+    }
+    
+    .tab-icon {
+        font-size: 1rem;
+    }
+}
+</style>

--- a/src/components/employment/QuestionCreateModal.vue
+++ b/src/components/employment/QuestionCreateModal.vue
@@ -5,7 +5,7 @@
         <v-tabs v-model="activeTab">
             <v-tab value="MULTIPLE">선택형</v-tab>
             <v-tab value="SUBJECTIVE">단답형</v-tab>
-            <v-tab value="DESCRIPTIVE">서술형</v-tab>
+            <!-- <v-tab value="DESCRIPTIVE">서술형</v-tab> -->
         </v-tabs>
 
         <v-select v-model="form.difficulty" :items="difficultyOptions" label="난이도" variant="outlined" class="mt-4" />
@@ -24,7 +24,6 @@ import { ref, onMounted, computed, watch } from 'vue'
 import { useToast } from 'vue-toastification'
 import MultipleQuestionForm from '@/components/employment/MultipleQuestionForm.vue'
 import SubjectiveForm from '@/components/employment/SubjectiveForm.vue'
-import DescriptiveQuestionForm from '@/components/employment/DescriptiveQuestionForm.vue'
 
 import { useMemberStore } from '@/stores/memberStore'
 import { useJobtestQuestionStore } from '@/stores/jobtestQuestionStore'
@@ -52,7 +51,7 @@ const currentComponent = computed(() => {
     switch (activeTab.value) {
         case 'MULTIPLE': return MultipleQuestionForm
         case 'SUBJECTIVE': return SubjectiveForm
-        default: return DescriptiveQuestionForm
+        default: return MultipleQuestionForm
     }
 })
 
@@ -98,17 +97,17 @@ function validateForm() {
         }
     }
 
-    if (form.value.type === 'DESCRIPTIVE') {
-        if (!form.value.gradingCriteria.length) {
-            toast.error('채점 기준을 입력해주세요.')
-            return false
-        }
-        const total = form.value.gradingCriteria.reduce((sum, c) => sum + c.scoreWeight, 0)
-        if (Math.abs(total - 1) > 0.001) {
-            toast.error('채점 기준 가중치의 합이 100%가 되어야 합니다.')
-            return false
-        }
-    }
+    // if (form.value.type === 'DESCRIPTIVE') {
+    //     if (!form.value.gradingCriteria.length) {
+    //         toast.error('채점 기준을 입력해주세요.')
+    //         return false
+    //     }
+    //     const total = form.value.gradingCriteria.reduce((sum, c) => sum + c.scoreWeight, 0)
+    //     if (Math.abs(total - 1) > 0.001) {
+    //         toast.error('채점 기준 가중치의 합이 100%가 되어야 합니다.')
+    //         return false
+    //     }
+    // }
 
     return true
 }

--- a/src/components/employment/QuestionView.vue
+++ b/src/components/employment/QuestionView.vue
@@ -9,7 +9,10 @@
       <MultipleChoice :options="question.options" :answer="answer" @select="val => $emit('updateAnswer', val)" />
     </div>
     <div v-else-if="question.type === QUESTION_TYPES.SUBJECTIVE">
-      <ShortAnswer :answer="answer" @input="val => { $emit('updateAnswer', val) }" />
+      <ShortAnswer :answer="answer" @input="val => { 
+        console.log('📝 QuestionView 단답형 답안 입력:', val)
+        $emit('updateAnswer', val) 
+      }" />
     </div>
   </div>
 </template>

--- a/src/components/employment/QuestionView.vue
+++ b/src/components/employment/QuestionView.vue
@@ -1,25 +1,41 @@
 <template>
   <div class="question-view">
     <div class="question-header">
-      <span class="question-number">{{ questionIndex + 1 }}.</span>
-      <span class="question-title">{{ question.title }}</span>
-      <span class="question-score">({{ question.score }}점)</span>
+      <div class="question-info">
+        <span class="question-number">{{ questionIndex + 1 }}</span>
+        <div class="question-content">
+          <h3 class="question-title">{{ question.title }}</h3>
+          <div class="question-meta">
+            <!-- <span class="question-type-tag" :style="getQuestionTypeStyle(question.questionType || question.type)">
+              {{ getQuestionTypeLabel(question.questionType || question.type) }}
+            </span> -->
+            <span class="question-score">
+              <v-icon class="score-icon">mdi-star</v-icon>
+              {{ question.score }}점
+            </span>
+          </div>
+        </div>
+      </div>
     </div>
-    <div v-if="question.type === QUESTION_TYPES.MULTIPLE">
-      <MultipleChoice :options="question.options" :answer="answer" @select="val => $emit('updateAnswer', val)" />
-    </div>
-    <div v-else-if="question.type === QUESTION_TYPES.SUBJECTIVE">
-      <ShortAnswer :answer="answer" @input="val => { 
-        console.log('📝 QuestionView 단답형 답안 입력:', val)
-        $emit('updateAnswer', val) 
-      }" />
+    
+    <div class="question-body">
+      <div v-if="getQuestionTypeKey(question.questionType || question.type) === 'MULTIPLE'">
+        <MultipleChoice :options="question.options" :answer="answer" @select="val => $emit('updateAnswer', val)" />
+      </div>
+      <div v-else-if="getQuestionTypeKey(question.questionType || question.type) === 'SUBJECTIVE'">
+        <ShortAnswer :answer="answer" @input="val => { 
+          console.log('📝 QuestionView 단답형 답안 입력:', val)
+          $emit('updateAnswer', val) 
+        }" />
+      </div>
     </div>
   </div>
 </template>
+
 <script setup>
 import MultipleChoice from '@/components/employment/MultipleChoice.vue'
 import ShortAnswer from '@/components/employment/ShortAnswer.vue'
-import { QUESTION_TYPES } from '@/constants/employment/questionTypes'
+import { getQuestionTypeLabel, getQuestionTypeColors } from '@/constants/employment/questionTypes.js'
 
 const props = defineProps({
   question: Object,
@@ -29,46 +45,214 @@ const props = defineProps({
     default: 0
   }
 })
+
+// 디버깅용 로그
+console.log('🔍 QuestionView - question:', {
+  type: props.question.type,
+  questionType: props.question.questionType,
+  question: props.question
+})
+
+const getQuestionTypeKey = (type) => {
+  console.log('🔍 getQuestionTypeKey input:', { type, typeOf: typeof type })
+  
+  // 문자열 "0", "1", "2" 처리
+  if (type === 0 || type === '0') return 'MULTIPLE'
+  if (type === 1 || type === '1') return 'SUBJECTIVE'
+  if (type === 2 || type === '2') return 'DESCRIPTIVE'
+  
+  // 문자열 타입 처리
+  if (type === 'MULTIPLE') return 'MULTIPLE'
+  if (type === 'SUBJECTIVE') return 'SUBJECTIVE'
+  if (type === 'DESCRIPTIVE') return 'DESCRIPTIVE'
+  
+  // 기본값
+  console.log('⚠️ Unknown question type:', type, 'defaulting to MULTIPLE')
+  return 'MULTIPLE'
+}
+
+const getQuestionTypeStyle = (type) => {
+  const key = getQuestionTypeKey(type)
+  const colors = getQuestionTypeColors(key);
+  return {
+    backgroundColor: colors.background,
+    color: colors.text,
+  };
+};
 </script>
+
 <style scoped>
 .question-view {
   width: 100%;
   margin-bottom: 32px;
+  background: white;
+  border-radius: 16px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+  overflow: hidden;
+  border: 1px solid rgba(0, 0, 0, 0.05);
+  transition: all 0.3s ease;
 }
+
+.question-view:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+}
+
 .question-header {
+  background: linear-gradient(135deg, #f8f9fa, #e9ecef);
+  padding: 24px;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.question-info {
   display: flex;
-  align-items: baseline;
-  gap: 8px;
-  font-size: 1.6rem;
-  font-weight: 700;
-  margin-bottom: 32px;
+  align-items: flex-start;
+  gap: 16px;
 }
+
 .question-number {
-  color: #222;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  background: linear-gradient(135deg, #1976d2, #42a5f5);
+  color: white;
+  border-radius: 50%;
+  font-size: 1.2rem;
+  font-weight: 700;
+  flex-shrink: 0;
+  box-shadow: 0 2px 8px rgba(25, 118, 210, 0.3);
 }
+
+.question-content {
+  flex: 1;
+}
+
 .question-title {
-  color: #222;
+  color: #1a237e;
+  font-size: 1.3rem;
+  font-weight: 600;
+  margin: 0 0 12px 0;
+  line-height: 1.4;
 }
+
+.question-meta {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.question-type-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 12px;
+  border-radius: 20px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  transition: all 0.2s ease;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.question-type-tag:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}
+
 .question-score {
-  font-size: 1.1rem;
-  font-weight: 400;
+  display: flex;
+  align-items: center;
+  gap: 6px;
   color: #666;
-  margin-left: 8px;
+  font-size: 0.9rem;
+  font-weight: 500;
 }
-.subjective-input {
-  width: 100%;
-  max-width: 600px;
-  padding: 18px 20px;
-  font-size: 1.1rem;
-  border: 2px solid #e5e5e5;
-  border-radius: 8px;
-  margin-bottom: 16px;
-  background: #fafbfc;
-  transition: border 0.2s;
+
+.score-icon {
+  color: #ffc107;
+  font-size: 1rem;
 }
-.subjective-input:focus {
-  border-color: #4A7C59;
-  outline: none;
-  background: #fff;
+
+.question-body {
+  padding: 24px;
+}
+
+/* 반응형 디자인 */
+@media (max-width: 960px) {
+  .question-view {
+    margin-bottom: 24px;
+    border-radius: 12px;
+  }
+  
+  .question-header {
+    padding: 20px;
+  }
+  
+  .question-info {
+    gap: 12px;
+  }
+  
+  .question-number {
+    width: 36px;
+    height: 36px;
+    font-size: 1.1rem;
+  }
+  
+  .question-title {
+    font-size: 1.2rem;
+  }
+  
+  .question-body {
+    padding: 20px;
+  }
+}
+
+@media (max-width: 600px) {
+  .question-view {
+    margin-bottom: 16px;
+    border-radius: 8px;
+  }
+  
+  .question-header {
+    padding: 16px;
+  }
+  
+  .question-info {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+  
+  .question-number {
+    width: 32px;
+    height: 32px;
+    font-size: 1rem;
+  }
+  
+  .question-title {
+    font-size: 1.1rem;
+    margin-bottom: 8px;
+  }
+  
+  .question-meta {
+    gap: 8px;
+  }
+  
+  .question-type-tag {
+    padding: 4px 8px;
+    font-size: 0.7rem;
+  }
+  
+  .question-score {
+    font-size: 0.85rem;
+  }
+  
+  .question-body {
+    padding: 16px;
+  }
 }
 </style>

--- a/src/components/employment/ShortAnswer.vue
+++ b/src/components/employment/ShortAnswer.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 
 const props = defineProps({
   answer: [String, Number, null]
@@ -18,9 +18,21 @@ const props = defineProps({
 const emit = defineEmits(['input'])
 
 const onInput = (e) => {
-  console.log('ShortAnswer emit:', e.target.value)
+  console.log('🔤 ShortAnswer 입력 이벤트:', {
+    value: e.target.value,
+    valueType: typeof e.target.value,
+    propsAnswer: props.answer
+  })
   emit('input', e.target.value)
 }
+
+// props.answer가 변경될 때마다 로그 출력
+watch(() => props.answer, (newVal) => {
+  console.log('📥 ShortAnswer props.answer 변경:', {
+    newValue: newVal,
+    valueType: typeof newVal
+  })
+}, { immediate: true })
 </script>
 
 <style scoped>

--- a/src/components/employment/ShortAnswer.vue
+++ b/src/components/employment/ShortAnswer.vue
@@ -1,11 +1,20 @@
 <template>
-  <input
-    class="short-answer-input"
-    type="text"
-    :value="answer ?? ''"
-    @input="onInput"
-    placeholder="답안을 입력하세요"
-  />
+  <div class="short-answer-container">
+    <div class="input-label">
+      <v-icon class="label-icon">mdi-text-box-outline</v-icon>
+      답안 입력
+    </div>
+    <div class="input-wrapper">
+      <input
+        class="short-answer-input"
+        type="text"
+        :value="answer ?? ''"
+        @input="onInput"
+        placeholder="답안을 입력하세요"
+      />
+      <div class="input-focus-border"></div>
+    </div>
+  </div>
 </template>
 
 <script setup>
@@ -36,20 +45,157 @@ watch(() => props.answer, (newVal) => {
 </script>
 
 <style scoped>
-.short-answer-input {
+.short-answer-container {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.input-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: #555;
+}
+
+.label-icon {
+  color: #1976d2;
+  font-size: 1rem;
+}
+
+.input-wrapper {
+  position: relative;
   width: 100%;
   max-width: 600px;
-  padding: 18px 20px;
-  font-size: 1.1rem;
-  border: 2px solid #e5e5e5;
-  border-radius: 8px;
-  margin-bottom: 16px;
-  background: #fafbfc;
-  transition: border 0.2s;
 }
-.short-answer-input:focus {
-  border-color: #4A7C59;
+
+.short-answer-input {
+  width: 100%;
+  padding: 16px 20px;
+  font-size: 1rem;
+  border: 2px solid #e0e0e0;
+  border-radius: 12px;
+  background: #fafbfc;
+  transition: all 0.2s ease;
   outline: none;
+  font-family: inherit;
+  line-height: 1.5;
+}
+
+.short-answer-input::placeholder {
+  color: #999;
+  font-style: italic;
+}
+
+.short-answer-input:hover {
+  border-color: #1976d2;
+  background: #f8f9fa;
+  box-shadow: 0 2px 8px rgba(25, 118, 210, 0.1);
+}
+
+.short-answer-input:focus {
+  border-color: #1976d2;
   background: #fff;
+  box-shadow: 0 4px 12px rgba(25, 118, 210, 0.15);
+  transform: translateY(-1px);
+}
+
+.input-focus-border {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border: 2px solid transparent;
+  border-radius: 12px;
+  pointer-events: none;
+  transition: all 0.2s ease;
+}
+
+.short-answer-input:focus + .input-focus-border {
+  border-color: #1976d2;
+  box-shadow: 0 0 0 4px rgba(25, 118, 210, 0.1);
+}
+
+/* 입력값이 있을 때 스타일 */
+.short-answer-input:not(:placeholder-shown) {
+  border-color: #4caf50;
+  background: #f8fff9;
+}
+
+.short-answer-input:not(:placeholder-shown):focus {
+  border-color: #4caf50;
+  box-shadow: 0 4px 12px rgba(76, 175, 80, 0.15);
+}
+
+.short-answer-input:not(:placeholder-shown) + .input-focus-border {
+  border-color: #4caf50;
+}
+
+/* 애니메이션 효과 */
+@keyframes inputGlow {
+  0% {
+    box-shadow: 0 0 0 0 rgba(25, 118, 210, 0.4);
+  }
+  70% {
+    box-shadow: 0 0 0 10px rgba(25, 118, 210, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(25, 118, 210, 0);
+  }
+}
+
+.short-answer-input:focus {
+  animation: inputGlow 0.6s ease-out;
+}
+
+/* 반응형 디자인 */
+@media (max-width: 600px) {
+  .input-label {
+    font-size: 0.9rem;
+  }
+  
+  .label-icon {
+    font-size: 0.9rem;
+  }
+  
+  .short-answer-input {
+    padding: 14px 16px;
+    font-size: 0.95rem;
+    border-radius: 8px;
+  }
+  
+  .input-focus-border {
+    border-radius: 8px;
+  }
+  
+  .input-wrapper {
+    max-width: none;
+  }
+}
+
+/* 다크 모드 대응 */
+@media (prefers-color-scheme: dark) {
+  .short-answer-input {
+    background: #2d3748;
+    border-color: #4a5568;
+    color: #e2e8f0;
+  }
+  
+  .short-answer-input::placeholder {
+    color: #718096;
+  }
+  
+  .short-answer-input:hover {
+    background: #4a5568;
+    border-color: #63b3ed;
+  }
+  
+  .short-answer-input:focus {
+    background: #2d3748;
+    border-color: #63b3ed;
+  }
 }
 </style>

--- a/src/components/employment/SubjectiveForm.vue
+++ b/src/components/employment/SubjectiveForm.vue
@@ -1,7 +1,36 @@
 <template>
-    <div>
-        <v-textarea label="문제를 입력해주세요." v-model="form.content" auto-grow :error-messages="errors.content" />
-        <v-text-field label="정답을 입력해주세요." v-model="form.answer" :error-messages="errors.answer" />
+    <div class="subjective-form">
+        <div class="form-section">
+            <div class="form-label">
+                <v-icon class="label-icon">mdi-help-circle</v-icon>
+                문제 내용
+            </div>
+            <v-textarea 
+                label="문제를 입력해주세요." 
+                v-model="form.content" 
+                auto-grow 
+                :error-messages="errors.content"
+                variant="outlined"
+                rows="4"
+                class="question-textarea"
+                prepend-inner-icon="mdi-text-box-outline"
+            />
+        </div>
+        
+        <div class="form-section">
+            <div class="form-label">
+                <v-icon class="label-icon">mdi-check-circle</v-icon>
+                정답
+            </div>
+            <v-text-field 
+                label="정답을 입력해주세요." 
+                v-model="form.answer" 
+                :error-messages="errors.answer"
+                variant="outlined"
+                class="answer-input"
+                prepend-inner-icon="mdi-lightbulb-outline"
+            />
+        </div>
     </div>
 </template>
 
@@ -14,3 +43,72 @@ defineProps({
     }
 });
 </script>
+
+<style scoped>
+.subjective-form {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.form-section {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.form-label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.95rem;
+    font-weight: 500;
+    color: #555;
+}
+
+.label-icon {
+    color: #1976d2;
+    font-size: 1rem;
+}
+
+.question-textarea {
+    border-radius: 8px;
+}
+
+.question-textarea :deep(.v-field) {
+    border-radius: 8px;
+    transition: all 0.2s ease;
+}
+
+.question-textarea :deep(.v-field:hover) {
+    box-shadow: 0 2px 8px rgba(25, 118, 210, 0.1);
+}
+
+.answer-input {
+    border-radius: 8px;
+}
+
+.answer-input :deep(.v-field) {
+    border-radius: 8px;
+    transition: all 0.2s ease;
+}
+
+.answer-input :deep(.v-field:hover) {
+    box-shadow: 0 2px 8px rgba(25, 118, 210, 0.1);
+}
+
+/* 반응형 디자인 */
+@media (max-width: 600px) {
+    .subjective-form {
+        gap: 20px;
+    }
+    
+    .form-label {
+        font-size: 0.9rem;
+    }
+    
+    .label-icon {
+        font-size: 0.9rem;
+    }
+}
+</style>

--- a/src/constants/employment/difficulty.js
+++ b/src/constants/employment/difficulty.js
@@ -7,24 +7,45 @@ export const DIFFICULTY_MAP = {
     'HARD': '어려움'
 };
 
+export const DIFFICULTY_TYPES = {
+    'EASY': '0',
+    'MEDIUM': '1',
+    'HARD': '2'
+};
+
 /**
  * 실무테스트 난이도 색상 매핑
  */
 export const DIFFICULTY_COLORS = {
     'EASY': {
-        background: '#A5D6A7',
-        text: '#2E7D32',
-        hover: 'rgba(165, 214, 167, 0.3)'
+        background: '#e8f5e9',
+        text: '#2e7d32',
+        hover: 'rgba(232, 245, 233, 0.4)'
     },
     'MEDIUM': {
-        background: '#90CAF9',
-        text: '#1565C0',
-        hover: 'rgba(144, 202, 249, 0.3)'
+        background: '#e8eaf6',
+        text: '#3f51b5',
+        hover: 'rgba(232, 234, 246, 0.4)'
     },
     'HARD': {
-        background: '#EF9A9A',
-        text: '#C62828',
-        hover: 'rgba(239, 154, 154, 0.3)'
+        background: '#ffcdd2',
+        text: '#c62828',
+        hover: 'rgba(255, 205, 210, 0.4)'
+    },
+    '쉬움': {
+        background: '#e8f5e9',
+        text: '#2e7d32',
+        hover: 'rgba(232, 245, 233, 0.4)'
+    },
+    '보통': {
+        background: '#e8eaf6',
+        text: '#3f51b5',
+        hover: 'rgba(232, 234, 246, 0.4)'
+    },
+    '어려움': {
+        background: '#ffcdd2',
+        text: '#c62828',
+        hover: 'rgba(255, 205, 210, 0.4)'
     }
 };
 

--- a/src/constants/employment/difficulty.js
+++ b/src/constants/employment/difficulty.js
@@ -8,10 +8,61 @@ export const DIFFICULTY_MAP = {
 };
 
 /**
+ * 실무테스트 난이도 색상 매핑
+ */
+export const DIFFICULTY_COLORS = {
+    'EASY': {
+        background: '#A5D6A7',
+        text: '#2E7D32',
+        hover: 'rgba(165, 214, 167, 0.3)'
+    },
+    'MEDIUM': {
+        background: '#90CAF9',
+        text: '#1565C0',
+        hover: 'rgba(144, 202, 249, 0.3)'
+    },
+    'HARD': {
+        background: '#EF9A9A',
+        text: '#C62828',
+        hover: 'rgba(239, 154, 154, 0.3)'
+    }
+};
+
+/**
  * 실무테스트 난이도 한글화
  * @param {keyof typeof DIFFICULTY_MAP} difficulty - 난이도
  * @returns {string} 한글화된 난이도
  */
 export const getDifficultyLabel = (difficulty) => {
     return DIFFICULTY_MAP[difficulty] || difficulty;
+};
+
+/**
+ * 실무테스트 난이도 색상 정보 반환
+ * @param {keyof typeof DIFFICULTY_COLORS} difficulty - 난이도
+ * @returns {Object} 색상 정보 객체
+ */
+export const getDifficultyColors = (difficulty) => {
+    return DIFFICULTY_COLORS[difficulty] || DIFFICULTY_COLORS.MEDIUM;
+};
+
+/**
+ * 실무테스트 난이도 CSS 클래스명 반환
+ * @param {keyof typeof DIFFICULTY_MAP} difficulty - 난이도
+ * @returns {string} CSS 클래스명
+ */
+export const getDifficultyClass = (difficulty) => {
+    switch (difficulty) {
+        case 'EASY':
+        case '쉬움':
+            return 'difficulty-easy'
+        case 'MEDIUM':
+        case '보통':
+            return 'difficulty-medium'
+        case 'HARD':
+        case '어려움':
+            return 'difficulty-hard'
+        default:
+            return 'difficulty-medium'
+    }
 }; 

--- a/src/constants/employment/questionTypes.js
+++ b/src/constants/employment/questionTypes.js
@@ -32,6 +32,21 @@ export const QUESTION_TYPE_COLORS = {
         background: '#BA68C8',
         text: '#7B1FA2',
         hover: 'rgba(186, 104, 200, 0.3)'
+    },
+    '선택형': {
+        background: '#81C784',
+        text: '#2E7D32',
+        hover: 'rgba(129, 199, 132, 0.3)'
+    },
+    '단답형': {
+        background: '#FFB74D',
+        text: '#E65100',
+        hover: 'rgba(255, 183, 77, 0.3)'
+    },
+    '서술형': {
+        background: '#BA68C8',
+        text: '#7B1FA2',
+        hover: 'rgba(186, 104, 200, 0.3)'
     }
 };
 
@@ -41,7 +56,7 @@ export const QUESTION_TYPE_COLORS = {
  * @returns {string} 한글화된 문제 유형
  */
 export const getQuestionTypeLabel = (type) => {
-    return QUESTION_TYPE_MAP[type] || type;
+    return QUESTION_TYPE_MAP[type] || type || '미지정';
 };
 
 /**

--- a/src/constants/employment/questionTypes.js
+++ b/src/constants/employment/questionTypes.js
@@ -15,10 +15,65 @@ export const QUESTION_TYPES = {
 };
 
 /**
+ * 실무테스트 문제 유형 색상 매핑
+ */
+export const QUESTION_TYPE_COLORS = {
+    'MULTIPLE': {
+        background: '#81C784',
+        text: '#2E7D32',
+        hover: 'rgba(129, 199, 132, 0.3)'
+    },
+    'SUBJECTIVE': {
+        background: '#FFB74D',
+        text: '#E65100',
+        hover: 'rgba(255, 183, 77, 0.3)'
+    },
+    'DESCRIPTIVE': {
+        background: '#BA68C8',
+        text: '#7B1FA2',
+        hover: 'rgba(186, 104, 200, 0.3)'
+    }
+};
+
+/**
  * 실무테스트 문제 유형 한글화
  * @param {keyof typeof QUESTION_TYPE_MAP} type - 문제 유형
  * @returns {string} 한글화된 문제 유형
  */
 export const getQuestionTypeLabel = (type) => {
     return QUESTION_TYPE_MAP[type] || type;
+};
+
+/**
+ * 실무테스트 문제 유형 색상 정보 반환
+ * @param {keyof typeof QUESTION_TYPE_COLORS} type - 문제 유형
+ * @returns {Object} 색상 정보 객체
+ */
+export const getQuestionTypeColors = (type) => {
+    return QUESTION_TYPE_COLORS[type] || {
+        background: '#90A4AE',
+        text: '#37474F',
+        hover: 'rgba(144, 164, 174, 0.3)'
+    };
+};
+
+/**
+ * 실무테스트 문제 유형 CSS 클래스명 반환
+ * @param {keyof typeof QUESTION_TYPE_MAP} type - 문제 유형
+ * @returns {string} CSS 클래스명
+ */
+export const getQuestionTypeClass = (type) => {
+    switch (type) {
+        case 'MULTIPLE':
+        case '선택형':
+            return 'type-multiple'
+        case 'SUBJECTIVE':
+        case '단답형':
+            return 'type-subjective'
+        case 'DESCRIPTIVE':
+        case '서술형':
+            return 'type-descriptive'
+        default:
+            return 'type-default'
+    }
 }; 

--- a/src/dto/approval/approvalCategory/approvalCategoryDTO.js
+++ b/src/dto/approval/approvalCategory/approvalCategoryDTO.js
@@ -1,11 +1,12 @@
 class ApprovalCategoryDTO {
-    constructor(id, name) {
+    constructor(id, name, approvalCategoryId = null) {
         this.id = id;
         this.name = name;
+        this.approvalCategoryId = approvalCategoryId;
     }
 
     static fromJSON(json) {
-        return new ApprovalCategoryDTO(json.id, json.name);
+        return new ApprovalCategoryDTO(json.id, json.name, json.approval_category_id);
     }
 }
 

--- a/src/dto/employment/jobtest/jobtestDetailDTO.js
+++ b/src/dto/employment/jobtest/jobtestDetailDTO.js
@@ -1,9 +1,10 @@
 // 문제 요약 DTO
 export class JobtestQuestionSummaryDTO {
-    constructor(score, optionNumber, questionId, difficulty, content) {
+    constructor(score, optionNumber, questionId, type, difficulty, content) {
         this.score = score;
         this.optionNumber = optionNumber;
         this.questionId = questionId;
+        this.type = type;
         this.difficulty = difficulty;
         this.content = content;
     }
@@ -13,6 +14,7 @@ export class JobtestQuestionSummaryDTO {
             json.score,
             json.optionNumber,
             json.questionId,
+            json.type,
             json.difficulty,
             json.content
         );
@@ -23,6 +25,7 @@ export class JobtestQuestionSummaryDTO {
             score: this.score,
             optionNumber: this.optionNumber,
             questionId: this.questionId,
+            type: this.type,
             difficulty: this.difficulty
         };
     }

--- a/src/dto/employment/jobtest/jobtestDetailResponseDTO.js
+++ b/src/dto/employment/jobtest/jobtestDetailResponseDTO.js
@@ -1,0 +1,22 @@
+export default class JobtestDetailResponseDTO {
+  constructor(data) {
+    this.id = data.id
+    this.title = data.title
+    this.testTime = data.testTime
+    this.difficulty = data.difficulty
+    this.createdName = data.createdName
+    this.updatedName = data.updatedName
+    this.createdAt = data.createdAt
+    this.updatedAt = data.updatedAt
+    this.startedAt = data.startedAt
+    this.endedAt = data.endedAt
+    this.questions = (data.questions || []).map(q => ({
+      id: q.questionId,
+      content: q.content,
+      score: q.score,
+      type: q.type,
+      difficulty: q.difficulty,
+    }))
+    this.applications = data.applications || []
+  }
+} 

--- a/src/router/employment.routes.js
+++ b/src/router/employment.routes.js
@@ -112,7 +112,11 @@ export const employmentRoutes = [
         name: 'JobtestEnter',
         component: () => import('@/views/employment/JobtestEnterPage.vue'),
         props: true,
-        meta: { requiresAuth: false }
+        meta: { 
+            requiresAuth: false,
+            hideHeader: true,
+            hideSidebar: true
+        }
     },
     // 실무테스트 응시 페이지
     {
@@ -120,7 +124,11 @@ export const employmentRoutes = [
         name: 'JobtestExam',
         component: () => import('@/views/employment/JobtestExamPage.vue'),
         props: true,
-        meta: { requiresAuth: false }
+        meta: { 
+            requiresAuth: false,
+            hideHeader: true,
+            hideSidebar: true
+        }
     },
 
     //    <------------------- 채용공고 -------------------->

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -41,6 +41,16 @@ const routes = [
         component: () => import('@/views/career/ApplicantRegisterPage.vue'),
         meta: { requiresAuth: false, hideHeader: true, hideSidebar: true }
     },
+    {
+        path: '/access-denied',
+        name: 'Forbidden',
+        component: () => import('@/views/errors/ForbiddenPage.vue'),
+    },
+    {
+        path: '/:pathMatch(.*)*',
+        name: 'NotFound',
+        component: () => import('@/views/errors/NotFoundPage.vue'),
+    },
     ...allRouteModules
 ];
 

--- a/src/services/answerService.js
+++ b/src/services/answerService.js
@@ -26,14 +26,20 @@ export const getAnswersByApplicationJobtestId = async (applicationJobtestId, opt
 
 // 답안 제출 (응시 페이지에서 다음 버튼을 누를 때 호출)
 export const postAnswer = async (answerDTO, options = {}) => {
+    console.log('🌐 answerService.postAnswer 호출:', answerDTO)
+    
     return withErrorHandling(async () => {
         const response = await api.post(JobtestAPI.ANSWERS, answerDTO);
+        console.log('📡 API 응답:', response.data)
+        
         const apiResponse = ApiResponseDTO.fromJSON(response.data);
 
         if (!apiResponse.success) {
+            console.error('❌ API 응답 실패:', apiResponse)
             throwCustomApiError(apiResponse.code, apiResponse.message, 400);
         }
 
+        console.log('✅ API 응답 성공:', apiResponse.message)
         return apiResponse.message;
     }, options);
 }

--- a/src/services/approvalService.js
+++ b/src/services/approvalService.js
@@ -27,6 +27,25 @@ export const getApprovalCategories = async (options = {}) => {
     }, options);
 };
 
+// 하위 카테고리만 조회 (상위 카테고리 제외)
+export const getSubCategories = async (options = {}) => {
+    return withErrorHandling(async () => {
+        const response = await api.get(ApprovalAPI.CATEGORIES);
+        const apiResponse = ApiResponseDTO.fromJSON(response.data);
+
+        if (!apiResponse.success) {
+            throwCustomApiError(apiResponse.code, apiResponse.message, 400);
+        }
+        
+        // approvalCategoryId가 null이 아닌 것들만 필터링 (하위 카테고리만)
+        const subCategories = (apiResponse.data || []).filter(category => 
+            category.approvalCategoryId !== null
+        );
+
+        return subCategories.map(ApprovalCategoryDTO.fromJSON);
+    }, options);
+};
+
 // 선택 카테고리의 결재 항목 조회
 export const getApprovalCategoryItems = async (categoryId, options = {}) => {
     return withErrorHandling(async () => {

--- a/src/services/jobtestService.js
+++ b/src/services/jobtestService.js
@@ -68,6 +68,20 @@ export const createApplicationJobtestService = async (
     }, options);
 }
 
+// applicationJobtest 상세 정보 조회
+export const getApplicationJobtestDetailService = async (applicationJobtestId, options = {}) => {
+    return withErrorHandling(async () => {
+        const response = await api.get(JobtestAPI.APPLICATION_JOBTEST_DETAIL(applicationJobtestId));
+        const apiResponse = ApiResponseDTO.fromJSON(response.data);
+        
+        if (!apiResponse.success) {
+            throwCustomApiError(apiResponse.code, apiResponse.message, 400);
+        }
+        
+        return apiResponse.data;
+    }, options);
+};
+
 // 실무테스트 입장
 export const verifyJobtestEntryService = async (jobtestId, dto, options = {}) => {
     return withErrorHandling(async () => {

--- a/src/services/jobtestService.js
+++ b/src/services/jobtestService.js
@@ -59,7 +59,7 @@ export const createApplicationJobtestService = async (
     options = {}
 ) => {
     return withErrorHandling(async () => {
-        const response = await api.post(JobtestAPI.APPLICATION_JOBTESTS, dto);
+        const response = await api.post(JobtestAPI.APPLICATION_JOBTESTS, dto.toJSON());
         const apiResponse = ApiResponseDTO.fromJSON(response.data);
         if (!apiResponse.success) {
             throwCustomApiError(apiResponse.code, apiResponse.message, 400);

--- a/src/stores/applicantStore.js
+++ b/src/stores/applicantStore.js
@@ -283,6 +283,30 @@ export const useApplicantStore = defineStore('applicant', () => {
         selectedApplicants.value = [];
     };
 
+    // 실무테스트 할당 정보 업데이트
+    const updateJobtestAssignment = (assignedResults) => {
+        assignedResults.forEach(result => {
+            const application = applicantList.value.find(
+                app => app.applicationId === result.applicationId
+            );
+            
+            if (application) {
+                application.applicationJobtestId = result.applicationJobtestId;
+                application.jobtestId = result.jobtestId;
+                application.jobtestAssignedAt = result.assignedAt;
+                application.hasJobtest = true;
+            }
+        });
+    };
+
+    // 실무테스트 할당 여부 확인
+    const hasJobtestAssignment = (applicationId) => {
+        const application = applicantList.value.find(
+            app => app.applicationId === applicationId
+        );
+        return application?.hasJobtest || false;
+    };
+
     return {
         // 상태
         applicantList,
@@ -313,6 +337,8 @@ export const useApplicantStore = defineStore('applicant', () => {
         setSelectedApplicants,
         addSelectedApplicant,
         removeSelectedApplicant,
-        clearSelectedApplicants
+        clearSelectedApplicants,
+        updateJobtestAssignment,
+        hasJobtestAssignment
     };
 });

--- a/src/stores/approvalWriteStore.js
+++ b/src/stores/approvalWriteStore.js
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia';
 import { ref } from 'vue';
 import {
     getApprovalCategories,
+    getSubCategories,
     getApprovalCategoryItems,
     createApprovalService,
     getApprovalLine,
@@ -37,7 +38,7 @@ export const useApprovalWriteStore = defineStore('approvalWrite', () => {
     const fetchCategories = async () => {
         loading.value = true;
         try {
-            categoryList.value = await getApprovalCategories();
+            categoryList.value = await getSubCategories();
         } finally {
             loading.value = false;
         }

--- a/src/stores/jobtestExamStore.js
+++ b/src/stores/jobtestExamStore.js
@@ -41,7 +41,20 @@ export const useJobtestExamStore = defineStore('jobtestExam', () => {
     }
 
     async function saveAnswer({ content, applicationJobTestId, questionId }) {
-        return await postAnswer({ content, applicationJobTestId, questionId })
+        console.log('💾 jobtestExamStore.saveAnswer 호출:', {
+            content,
+            applicationJobTestId,
+            questionId
+        })
+        
+        try {
+            const result = await postAnswer({ content, applicationJobTestId, questionId })
+            console.log('✅ jobtestExamStore.saveAnswer 성공:', result)
+            return result
+        } catch (error) {
+            console.error('❌ jobtestExamStore.saveAnswer 실패:', error)
+            throw error
+        }
     }
 
     async function submitAnswers(applicationJobTestId) {

--- a/src/stores/jobtestQuestionStore.js
+++ b/src/stores/jobtestQuestionStore.js
@@ -133,27 +133,13 @@ export const useJobtestQuestionStore = defineStore('question', () => {
 
         try {
             const response = await getQuestionsService();
-
-            const mapped = response
-                .filter(q => q.type !== 'DESCRIPTIVE') // 서술형 우선 제외
-                .sort((a, b) => b.id - a.id)
-                .map(question => ({
-                    ...question,
-                    id: Number(question.id),
-                    selected: false,
-                    type: getQuestionTypeLabel(question.type),
-                    difficulty: getDifficultyLabel(question.difficulty)
-                }));
-
-            questions.value.splice(0, questions.value.length, ...mapped);
+            questions.value = response;
         } catch (err) {
-            error.value = err.message;
-            throw err;
+            error.value = err.message || '문제 목록을 불러오는 데 실패했습니다.';
         } finally {
             loading.value = false;
         }
     };
-
 
     // ✅ 문제 일괄 삭제
     const deleteSelectedQuestions = async () => {
@@ -205,18 +191,18 @@ export const useJobtestQuestionStore = defineStore('question', () => {
     };
 
     // ✅ 단일 문제 삭제
-const deleteQuestion = async (questionId, type) => {
-    try {
-        if (type === '선택형' || type === 'MULTIPLE') {
-            await deleteQuestionOptionsByQuestionId(questionId)
+    const deleteQuestion = async (questionId, type) => {
+        try {
+            if (type === '선택형' || type === 'MULTIPLE') {
+                await deleteQuestionOptionsByQuestionId(questionId)
+            }
+            await deleteQuestionService(questionId)
+            await fetchQuestions()
+        } catch (err) {
+            error.value = err.message || '문제 삭제 중 오류 발생'
+            throw err
         }
-        await deleteQuestionService(questionId)
-        await fetchQuestions()
-    } catch (err) {
-        error.value = err.message || '문제 삭제 중 오류 발생'
-        throw err
     }
-}
 
     // ✅ 선택 관련 유틸
     const toggleQuestionSelection = (questionId) => {

--- a/src/utils/errorHandler.js
+++ b/src/utils/errorHandler.js
@@ -54,10 +54,9 @@ export const handleApiError = (error, options = { showToast: true, redirect: tru
                 }
                 break;
             case 403:
-                router.push('/access-denied');      // 🚩 TODO : 권한이 필요하다고 뜨는 페이지
-                break;
+                router.push('/access-denied');
             case 404:
-                router.push('/not-found');          // 🚩 TODO : 404 페이지
+                router.push('/not-found');
                 break;
         }
     }

--- a/src/views/approval/ApprovalCreatePage.vue
+++ b/src/views/approval/ApprovalCreatePage.vue
@@ -11,9 +11,10 @@
                     <v-row class="mb-6" align="center">
                         <v-col cols="2" class="approval-label">결재 유형</v-col>
                         <v-col cols="4">
-                            <v-select v-model="form.categoryId" :items="categoryList" item-title="name" item-value="id"
-                                label="유형 선택" variant="solo" density="comfortable" class="approval-input" hide-details
-                                @update:model-value="onCategoryChange" clearable required />
+                            <v-select v-model="form.categoryId" :items="filteredCategoryList" item-title="name"
+                                item-value="id" label="유형 선택" variant="solo" density="comfortable"
+                                class="approval-input" hide-details @update:model-value="onCategoryChange" clearable
+                                required />
                         </v-col>
                         <v-col cols="2" class="approval-label">작성일</v-col>
                         <v-col cols="4">
@@ -43,45 +44,21 @@
                                 <!-- 직무 드롭다운 -->
                                 <v-select
                                     v-if="item.inputType === InputTypeEnum.NUMBER && dropdownMap[item.id] === 'job'"
-                                    v-model="form.contents[idx].content"
-                                    :items="jobOptions"
-                                    item-title="name"
-                                    item-value="id"
-                                    :label="item.name"
-                                    variant="solo"
-                                    density="comfortable"
-                                    class="approval-input"
-                                    hide-details
-                                    required
-                                />
+                                    v-model="form.contents[idx].content" :items="jobOptions" item-title="name"
+                                    item-value="id" :label="item.name" variant="solo" density="comfortable"
+                                    class="approval-input" hide-details required />
 
                                 <!-- 부서 드롭다운 -->
                                 <v-select
                                     v-else-if="item.inputType === InputTypeEnum.NUMBER && dropdownMap[item.id] === 'department'"
-                                    v-model="form.contents[idx].content"
-                                    :items="departmentOptions"
-                                    item-title="name"
-                                    item-value="id"
-                                    :label="item.name"
-                                    variant="solo"
-                                    density="comfortable"
-                                    class="approval-input"
-                                    hide-details
-                                    required
-                                />
+                                    v-model="form.contents[idx].content" :items="departmentOptions" item-title="name"
+                                    item-value="id" :label="item.name" variant="solo" density="comfortable"
+                                    class="approval-input" hide-details required />
 
                                 <!-- 나머지 숫자 입력 -->
-                                <v-text-field
-                                    v-else-if="item.inputType === InputTypeEnum.NUMBER"
-                                    v-model="form.contents[idx].content"
-                                    :label="item.name"
-                                    type="number"
-                                    variant="solo"
-                                    density="comfortable"
-                                    class="approval-input"
-                                    hide-details
-                                    required
-                                />
+                                <v-text-field v-else-if="item.inputType === InputTypeEnum.NUMBER"
+                                    v-model="form.contents[idx].content" :label="item.name" type="number" variant="solo"
+                                    density="comfortable" class="approval-input" hide-details required />
 
                                 <v-text-field v-else-if="item.inputType === InputTypeEnum.TEXT"
                                     v-model="form.contents[idx].content" :label="item.name" variant="solo"
@@ -165,7 +142,7 @@ const dropdownMap = {
 };
 
 // 부서 옵션 (API에서 조회)
-const departmentOptions = computed(() => 
+const departmentOptions = computed(() =>
     departmentStore.departmentList.map(dept => ({
         id: dept.id || dept.value,
         name: dept.name || dept.label
@@ -173,11 +150,15 @@ const departmentOptions = computed(() =>
 );
 
 // 직무 옵션 (API에서 조회)
-const jobOptions = computed(() => 
+const jobOptions = computed(() =>
     jobStore.jobList.map(job => ({
         id: job.id || job.value,
         name: job.name || job.label
     }))
+);
+
+const filteredCategoryList = computed(() =>
+    categoryList.value.filter(category => category.approvalCategoryId === null)
 );
 
 onMounted(async () => {

--- a/src/views/employment/JobtestAnswerDetailPage.vue
+++ b/src/views/employment/JobtestAnswerDetailPage.vue
@@ -1,96 +1,158 @@
 <template>
-  <v-container>
-    <v-row>
-      <v-col cols="4">
-        <h2 class="text-h6 font-weight-bold mb-4">객관식/단답형 답안 목록</h2>
-      </v-col>
-      <v-spacer />
-      <v-col cols="2">
-        <div class="mb-6">
-          <span class="font-weight-bold text-lg">총점:</span>
-          <span class="ml-2 text-xl" style="color: #388e3c;">{{ totalScore }}점</span>
+  <v-container class="answer-detail-page">
+    <!-- 헤더 섹션 -->
+    <div class="header-section">
+      <div class="header-actions">
+        <v-btn prepend-icon="mdi-arrow-left" variant="tonal" @click="goBack" class="back-btn">
+          뒤로가기
+        </v-btn>
+      </div>
+      <div class="header-content">
+        <div class="title-section">
+          <h2 class="text-h5 font-weight-bold">{{ applicantInfo?.jobtestTitle || '실무 테스트' }}</h2>
+          <p class="text-body-2 text-medium-emphasis mt-1">{{ applicantInfo?.applicantName || '지원자' }} - 실무 테스트 제출 답안</p>
+          
+          <!-- 지원자 정보 -->
+          <div v-if="applicantInfo" class="applicant-info">
+            <div class="applicant-card">
+              <div class="applicant-header">
+                <v-icon class="applicant-icon">mdi-account</v-icon>
+                <span class="applicant-name">{{ applicantInfo.applicantName || '지원자' }}</span>
+              </div>
+            </div>
+          </div>
         </div>
-      </v-col>
-    </v-row>
-    <v-row dense>
-      <v-col v-for="(answer, idx) in filteredAnswers" :key="answer.id" cols="12" md="12">
-        <v-card class="mb-6" :class="{
-          'bg-red-lighten-5': answer.isCorrect === 'WRONG',
-          'bg-green-lighten-5': answer.isCorrect === 'CORRECT'
-        }">
-          <v-card-title class="d-flex justify-space-between align-center pb-0">
-            <span class="font-weight-bold">{{ idx + 1 }}. {{ answer.question.content }}</span>
-            <span class="display-1" :class="{
-              'text-grey': answer.isCorrect === 'WRONG',
-              'text-success': answer.isCorrect === 'CORRECT'
-            }">
-              {{ answer.score }}/{{ answer.maxScore || 3 }}
-            </span>
-          </v-card-title>
+        <div class="score-section">
+          <div class="total-score-card">
+            <span class="score-label">총점</span>
+            <span class="score-value">{{ totalScore }}점</span>
+          </div>
+        </div>
+      </div>
+    </div>
 
-          <v-card-text>
-            <!-- 선택지가 있는 경우: 객관식 -->
-            <template v-if="hasOptions(answer)">
-              <div class="mb-3">
-                <div v-for="opt in answer.question.options" :key="opt.id" class="mb-1" :style="{
-                  color: isSelectedOption(answer, opt) ? '#222' : '#bbb',
-                  fontWeight: isSelectedOption(answer, opt) ? 'bold' : 'normal',
-                  fontSize: isSelectedOption(answer, opt) ? '1.1em' : '1em'
-                }">
-                  {{ opt.optionNumber }}. {{ opt.content }}
-                  <v-chip v-if="isCorrectOption(answer, opt)" color="success" size="x-small" class="ml-2">정답</v-chip>
-                  <v-chip v-else-if="isSelectedOption(answer, opt)" color="primary" size="x-small"
-                    class="ml-2">선택</v-chip>
+    <!-- 답안 목록 -->
+    <div class="answers-section">
+      <v-row dense>
+        <v-col v-for="(answer, idx) in filteredAnswers" :key="answer.id" cols="12" md="12">
+          <v-card class="answer-card mb-4" :class="{
+            'answer-wrong': answer.isCorrect === 'WRONG',
+            'answer-correct': answer.isCorrect === 'CORRECT',
+            'answer-partial': answer.isCorrect === 'PARTIAL'
+          }">
+            <v-card-title class="answer-header">
+              <div class="question-info">
+                <span class="question-number">{{ idx + 1 }}.</span>
+                <div class="question-details">
+                  <span class="question-content">{{ answer.question.content }}</span>
+                  <div class="question-meta">
+                    <span class="question-type-tag" :style="getQuestionTypeStyle(answer.question.type)">
+                      {{ getQuestionTypeLabel(answer.question.type) }}
+                    </span>
+                    <span class="question-difficulty-tag" :style="getDifficultyStyle(answer.question.difficulty)">
+                      {{ getDifficultyLabel(answer.question.difficulty) }}
+                    </span>
+                  </div>
                 </div>
               </div>
-              <v-divider class="my-6" />
-              <!-- 오답일 때 정답 강조 -->
-              <div v-if="answer.isCorrect === 'WRONG'" class="mt-6">
-                <span class="font-weight-bold">정답 :</span>
-                <span class="text-error font-weight-bold text-lg ml-2">
-                  {{ getAnswerContent(answer.question) }}
+              <div class="score-display">
+                <span class="score-text" :class="{
+                  'score-wrong': answer.isCorrect === 'WRONG',
+                  'score-correct': answer.isCorrect === 'CORRECT',
+                  'score-partial': answer.isCorrect === 'PARTIAL'
+                }">
+                  {{ answer.score }}/{{ answer.maxScore || 3 }}
                 </span>
               </div>
-            </template>
+            </v-card-title>
 
-            <!-- 선택지 없는 경우: 주관식 -->
-            <template v-else>
-              <div class="mb-2">
-                <span class="font-weight-bold">정답:</span>
-                <span class="ml-2">{{ answer.question.answer }}</span>
-              </div>
-              <div>
-                <span class="font-weight-bold">답변:</span>
-                <span class="ml-2">{{ answer.content }}</span>
-              </div>
-            </template>
+            <v-card-text class="answer-content">
+              <!-- 선택지가 있는 경우: 객관식 -->
+              <template v-if="hasOptions(answer)">
+                <div class="options-section">
+                  <div v-for="opt in answer.question.options" :key="opt.id" 
+                       class="option-item" 
+                       :class="{
+                         'option-selected': isSelectedOption(answer, opt),
+                         'option-correct': isCorrectOption(answer, opt)
+                       }">
+                    <span class="option-number">{{ opt.optionNumber }}.</span>
+                    <span class="option-content">{{ opt.content }}</span>
+                    <div class="option-badges">
+                      <v-chip v-if="isCorrectOption(answer, opt)" color="success" size="x-small" class="ml-2">
+                        정답
+                      </v-chip>
+                      <v-chip v-else-if="isSelectedOption(answer, opt)" color="primary" size="x-small" class="ml-2">
+                        선택
+                      </v-chip>
+                    </div>
+                  </div>
+                </div>
+                
+                <!-- 오답일 때 정답 강조 -->
+                <div v-if="answer.isCorrect === 'WRONG'" class="correct-answer-section">
+                  <v-divider class="my-4" />
+                  <div class="correct-answer-display">
+                    <span class="correct-label">정답:</span>
+                    <span class="correct-content">
+                      {{ getAnswerContent(answer.question) }}
+                    </span>
+                  </div>
+                </div>
+              </template>
 
-            <!-- 공통 정보 -->
-            <div class="mt-3 d-flex align-center justify-space-between">
-              <div>
-                <span class="font-weight-bold">채점 결과:</span>
-                <v-chip :color="getColor(answer.isCorrect)" class="ml-2" size="small">
-                  {{ getResultLabel(answer.isCorrect) }}
-                </v-chip>
-                <span class="ml-4">점수: <strong>{{ answer.score }}</strong></span>
-                <span class="ml-4">시도: <strong>{{ answer.attempt }}</strong>회</span>
+              <!-- 선택지 없는 경우: 주관식 -->
+              <template v-else>
+                <div class="subjective-answer-section">
+                  <div class="answer-row">
+                    <span class="answer-label">정답:</span>
+                    <span class="answer-text">{{ answer.question.answer }}</span>
+                  </div>
+                  <div class="answer-row">
+                    <span class="answer-label">답변:</span>
+                    <span class="answer-text">{{ answer.content }}</span>
+                  </div>
+                </div>
+              </template>
+
+              <!-- 공통 정보 -->
+              <div class="answer-footer">
+                <div class="answer-meta">
+                  <v-chip :color="getColor(answer.isCorrect)" class="result-chip" size="small">
+                    {{ getResultLabel(answer.isCorrect) }}
+                  </v-chip>
+                  <span class="meta-info">점수: <strong>{{ answer.score }}</strong></span>
+                  <span class="meta-info">시도: <strong>{{ answer.attempt }}</strong>회</span>
+                </div>
               </div>
-              <!-- <v-btn color="success" variant="tonal" size="large">정정하기</v-btn> -->
-            </div>
-          </v-card-text>
-        </v-card>
-      </v-col>
-    </v-row>
+            </v-card-text>
+          </v-card>
+        </v-col>
+      </v-row>
+    </div>
   </v-container>
 </template>
 
 <script setup>
-import { computed, onMounted } from 'vue';
+import { computed, onMounted, ref } from 'vue';
+import { useRouter, useRoute } from 'vue-router';
 import AnswerResponseDTO from '@/dto/employment/jobtest/answerResponseDTO';
 import { useAnswerStore } from '@/stores/answerStore';
+import { getDifficultyLabel, getDifficultyColors } from '@/constants/employment/difficulty.js';
+import { getQuestionTypeLabel, getQuestionTypeColors } from '@/constants/employment/questionTypes.js';
+import { getApplicationJobtestDetailService } from '@/services/jobtestService';
+import { getApplicationByIdService } from '@/services/applicationService';
+import { getApplicantByIdService } from '@/services/applicantService';
 
+const router = useRouter();
+const route = useRoute();
 const props = defineProps(['applicationJobtestId']);
 const answerStore = useAnswerStore();
+
+// 지원자 정보 상태
+const applicantInfo = ref(null);
+const applicationInfo = ref(null);
+const loadingApplicantInfo = ref(false);
 
 const answers = computed(() =>
   answerStore.answers.map(AnswerResponseDTO.fromJSON)
@@ -104,6 +166,66 @@ const filteredAnswers = computed(() =>
 const totalScore = computed(() =>
   filteredAnswers.value.reduce((sum, a) => sum + (a.score || 0), 0)
 );
+
+// 쿼리 파라미터에서 지원자 정보 확인
+const hasQueryApplicantInfo = computed(() => {
+  return route.query.applicantName && route.query.recruitmentTitle;
+});
+
+// 지원자 정보 가져오기
+const fetchApplicantInfo = async () => {
+  loadingApplicantInfo.value = true;
+  try {
+    // 쿼리 파라미터에 지원자 정보가 있으면 우선 사용
+    if (hasQueryApplicantInfo.value) {
+      applicantInfo.value = {
+        applicantName: route.query.applicantName,
+        recruitmentTitle: route.query.recruitmentTitle,
+        applicantId: route.query.applicantId,
+        applicationId: route.query.applicationId,
+        jobtestTitle: route.query.jobtestTitle || '실무 테스트',
+        submittedAt: null
+      };
+      console.log('Using query applicant info:', applicantInfo.value);
+      return;
+    }
+
+    // 쿼리 파라미터에 정보가 없으면 API 호출
+    // 1. applicationJobtest 상세 정보 가져오기
+    const applicationJobtestData = await getApplicationJobtestDetailService(Number(props.applicationJobtestId));
+    console.log('ApplicationJobtest data:', applicationJobtestData);
+    
+    // 2. applicationId를 통해 지원서 정보 가져오기
+    if (applicationJobtestData.applicationId) {
+      const applicationData = await getApplicationByIdService(applicationJobtestData.applicationId);
+      applicationInfo.value = applicationData;
+      console.log('Application data:', applicationData);
+      
+      // 3. applicantId를 통해 지원자 정보 가져오기
+      if (applicationData.applicantId) {
+        const applicantData = await getApplicantByIdService(applicationData.applicantId);
+        console.log('Applicant data:', applicantData);
+        
+        // 4. 모든 정보를 합쳐서 applicantInfo에 저장
+        applicantInfo.value = {
+          ...applicationJobtestData,
+          applicantName: applicantData.name,
+          applicantEmail: applicantData.email,
+          applicantPhone: applicantData.phone,
+          recruitmentTitle: applicationJobtestData.recruitmentTitle || '채용 공고 정보 없음',
+          jobtestTitle: applicationJobtestData.jobtestTitle || '실무 테스트',
+          submittedAt: applicationJobtestData.submittedAt,
+          applicationId: applicationJobtestData.applicationId,
+          applicantId: applicationData.applicantId
+        };
+      }
+    }
+  } catch (error) {
+    console.error('Failed to fetch applicant info:', error);
+  } finally {
+    loadingApplicantInfo.value = false;
+  }
+};
 
 function hasOptions(answer) {
   return answer.question.options && answer.question.options.length > 0;
@@ -148,6 +270,7 @@ function getColor(status) {
       return 'default';
   }
 }
+
 function getResultLabel(status) {
   switch (status) {
     case 'CORRECT':
@@ -161,11 +284,398 @@ function getResultLabel(status) {
   }
 }
 
+const getQuestionTypeStyle = (type) => {
+  const colors = getQuestionTypeColors(type);
+  return {
+    backgroundColor: colors.background,
+    color: colors.text,
+  };
+};
+
+const getDifficultyStyle = (difficulty) => {
+  const colors = getDifficultyColors(difficulty);
+  return {
+    backgroundColor: colors.background,
+    color: colors.text,
+  };
+};
+
+const goBack = () => {
+  router.go(-1);
+};
+
 onMounted(async () => {
   try {
-    await answerStore.fetchAnswers(Number(props.applicationJobtestId));
+    await Promise.all([
+      answerStore.fetchAnswers(Number(props.applicationJobtestId)),
+      fetchApplicantInfo()
+    ]);
   } catch (error) {
-    console.error('Failed to fetch answer:', error);
+    console.error('Failed to fetch data:', error);
   }
 });
 </script>
+
+<style scoped>
+.answer-detail-page {
+  padding: 24px;
+  background-color: #f5f7fa;
+  min-height: 100vh;
+}
+
+.header-section {
+  margin-bottom: 32px;
+}
+
+.header-actions {
+  margin-bottom: 16px;
+}
+
+.back-btn {
+  transition: all 0.2s ease-in-out;
+}
+
+.back-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+}
+
+.header-content {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 24px;
+}
+
+.title-section {
+  flex: 1;
+}
+
+.title-section h2 {
+  color: #1a237e;
+  margin-bottom: 4px;
+}
+
+.applicant-info {
+  margin-top: 16px;
+}
+
+.applicant-card {
+  background: white;
+  border-radius: 12px;
+  padding: 16px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  border: 1px solid #e0e0e0;
+}
+
+.applicant-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.applicant-icon {
+  color: #1976d2;
+  font-size: 1.2rem;
+}
+
+.applicant-name {
+  font-weight: 600;
+  font-size: 1.1rem;
+  color: #333;
+}
+
+.score-section {
+  flex-shrink: 0;
+}
+
+.total-score-card {
+  background: linear-gradient(135deg, #4caf50, #66bb6a);
+  color: white;
+  padding: 16px 24px;
+  border-radius: 12px;
+  text-align: center;
+  box-shadow: 0 4px 12px rgba(76, 175, 80, 0.3);
+  min-width: 120px;
+}
+
+.score-label {
+  display: block;
+  font-size: 0.875rem;
+  font-weight: 500;
+  opacity: 0.9;
+  margin-bottom: 4px;
+}
+
+.score-value {
+  display: block;
+  font-size: 1.75rem;
+  font-weight: 700;
+}
+
+.answers-section {
+  margin-top: 24px;
+}
+
+.answer-card {
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  transition: all 0.3s ease;
+  border: 2px solid transparent;
+}
+
+.answer-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.12);
+}
+
+.answer-wrong {
+  border-color: #ffebee;
+  background-color: #fff5f5;
+}
+
+.answer-correct {
+  border-color: #e8f5e8;
+  background-color: #f8fff8;
+}
+
+.answer-partial {
+  border-color: #fff8e1;
+  background-color: #fffef7;
+}
+
+.answer-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  padding: 20px 24px 16px;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.question-info {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  flex: 1;
+}
+
+.question-number {
+  font-weight: 700;
+  color: #1976d2;
+  font-size: 1.1rem;
+  flex-shrink: 0;
+}
+
+.question-details {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.question-content {
+  font-weight: 500;
+  line-height: 1.5;
+  color: #333;
+}
+
+.question-meta {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.question-type-tag,
+.question-difficulty-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 8px;
+  border-radius: 12px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  transition: all 0.2s ease;
+}
+
+.score-display {
+  flex-shrink: 0;
+  margin-left: 16px;
+}
+
+.score-text {
+  font-size: 1.25rem;
+  font-weight: 700;
+  padding: 8px 12px;
+  border-radius: 8px;
+  background-color: #f5f5f5;
+}
+
+.score-correct {
+  color: #2e7d32;
+  background-color: #e8f5e8;
+}
+
+.score-wrong {
+  color: #c62828;
+  background-color: #ffebee;
+}
+
+.score-partial {
+  color: #f57c00;
+  background-color: #fff8e1;
+}
+
+.answer-content {
+  padding: 20px 24px;
+}
+
+.options-section {
+  margin-bottom: 16px;
+}
+
+.option-item {
+  display: flex;
+  align-items: center;
+  padding: 12px 16px;
+  margin-bottom: 8px;
+  border-radius: 8px;
+  background-color: #fafafa;
+  border: 2px solid transparent;
+  transition: all 0.2s ease;
+}
+
+.option-selected {
+  background-color: #e3f2fd;
+  border-color: #2196f3;
+}
+
+.option-correct {
+  background-color: #e8f5e8;
+  border-color: #4caf50;
+}
+
+.option-number {
+  font-weight: 600;
+  color: #666;
+  margin-right: 12px;
+  min-width: 24px;
+}
+
+.option-content {
+  flex: 1;
+  font-weight: 500;
+}
+
+.option-badges {
+  display: flex;
+  gap: 4px;
+}
+
+.correct-answer-section {
+  margin-top: 16px;
+}
+
+.correct-answer-display {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  background-color: #e8f5e8;
+  border-radius: 8px;
+  border-left: 4px solid #4caf50;
+}
+
+.correct-label {
+  font-weight: 600;
+  color: #2e7d32;
+}
+
+.correct-content {
+  font-weight: 500;
+  color: #1b5e20;
+}
+
+.subjective-answer-section {
+  margin-bottom: 16px;
+}
+
+.answer-row {
+  display: flex;
+  align-items: flex-start;
+  margin-bottom: 12px;
+  gap: 12px;
+}
+
+.answer-label {
+  font-weight: 600;
+  color: #666;
+  min-width: 60px;
+  flex-shrink: 0;
+}
+
+.answer-text {
+  font-weight: 500;
+  color: #333;
+  line-height: 1.5;
+  flex: 1;
+}
+
+.answer-footer {
+  margin-top: 20px;
+  padding-top: 16px;
+  border-top: 1px solid #e0e0e0;
+}
+
+.answer-meta {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.result-chip {
+  font-weight: 600;
+}
+
+.meta-info {
+  color: #666;
+  font-size: 0.875rem;
+}
+
+.meta-info strong {
+  color: #333;
+}
+
+@media (max-width: 768px) {
+  .answer-detail-page {
+    padding: 16px;
+  }
+  
+  .header-content {
+    flex-direction: column;
+    gap: 16px;
+  }
+  
+  .total-score-card {
+    align-self: flex-end;
+  }
+  
+  .answer-header {
+    flex-direction: column;
+    gap: 12px;
+  }
+  
+  .score-display {
+    margin-left: 0;
+    align-self: flex-end;
+  }
+  
+  .answer-meta {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+}
+</style>

--- a/src/views/employment/JobtestAnswerDetailPage.vue
+++ b/src/views/employment/JobtestAnswerDetailPage.vue
@@ -306,6 +306,9 @@ const goBack = () => {
 
 onMounted(async () => {
   try {
+    // 페이지 로드 시 스크롤을 맨 위로 이동
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+    
     await Promise.all([
       answerStore.fetchAnswers(Number(props.applicationJobtestId)),
       fetchApplicantInfo()

--- a/src/views/employment/JobtestCreatePage.vue
+++ b/src/views/employment/JobtestCreatePage.vue
@@ -61,15 +61,15 @@
             </template>
             <!-- 문제 유형 -->
             <template #item.type="{ item }">
-                <span class="type-tag" :class="getTypeClass(item.type)">
-                    {{ item.type }}
+                <span class="tag-style" :style="getQuestionTypeStyle(item.type)">
+                    {{ getQuestionTypeLabel(item.type) }}
                 </span>
             </template>
             <!-- 난이도 -->
             <template #item.difficulty="{ item }">
-                <v-chip size="small" :color="getDifficultyColor(item.difficulty)" dark>
-                    {{ item.difficulty }}
-                </v-chip>
+                <span class="tag-style" :style="getDifficultyStyle(item.difficulty)">
+                    {{ getDifficultyLabel(item.difficulty) }}
+                </span>
             </template>
             <!-- 점수 입력 -->
             <template #item.score="{ item }">
@@ -124,6 +124,8 @@ import SuccessModal from '@/components/common/AlertModal.vue'
 import Modal from '@/components/common/Modal.vue'
 import JobtestQuestionDetailModal from '@/components/employment/JobtestQuestionDetailModal.vue'
 import Search from '@/components/common/Search.vue'
+import { getDifficultyLabel, getDifficultyColors } from '@/constants/employment/difficulty.js'
+import { getQuestionTypeLabel, getQuestionTypeColors } from '@/constants/employment/questionTypes.js'
 
 const router = useRouter();
 const route = useRoute()
@@ -214,30 +216,21 @@ const selectedQuestions = computed(() =>
     localQuestions.value.filter(q => selectedIds.value.includes(q.id))
 )
 
-const getDifficultyColor = level => {
-    switch (level) {
-        case '쉬움': return 'success'
-        case '보통': return 'primary'
-        case '어려움': return 'error'
-        default: return 'grey'
-    }
-}
+const getDifficultyStyle = (difficulty) => {
+    const colors = getDifficultyColors(difficulty);
+    return {
+        backgroundColor: colors.background,
+        color: colors.text
+    };
+};
 
-const getTypeClass = (type) => {
-    switch (type) {
-        case '선택형':
-        case 'MULTIPLE':
-            return 'type-multiple'
-        case '단답형':
-        case 'SUBJECTIVE':
-            return 'type-subjective'
-        case '서술형':
-        case 'DESCRIPTIVE':
-            return 'type-descriptive'
-        default:
-            return 'type-default'
-    }
-}
+const getQuestionTypeStyle = (type) => {
+    const colors = getQuestionTypeColors(type);
+    return {
+        backgroundColor: colors.background,
+        color: colors.text
+    };
+};
 
 const toggle = (item) => {
     if (selectedIds.value.includes(item.id)) {
@@ -431,7 +424,7 @@ onMounted(async () => {
     margin-left: 16px;
 }
 
-.type-tag {
+.tag-style {
     display: inline-flex;
     align-items: center;
     padding: 4px 8px;
@@ -442,25 +435,5 @@ onMounted(async () => {
     letter-spacing: 0.3px;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
     transition: all 0.2s ease;
-}
-
-.type-multiple {
-    background: #81C784;
-    color: #2E7D32;
-}
-
-.type-subjective {
-    background: #FFB74D;
-    color: #E65100;
-}
-
-.type-descriptive {
-    background: #BA68C8;
-    color: #7B1FA2;
-}
-
-.type-default {
-    background: #90A4AE;
-    color: #37474F;
 }
 </style>

--- a/src/views/employment/JobtestCreatePage.vue
+++ b/src/views/employment/JobtestCreatePage.vue
@@ -61,7 +61,9 @@
             </template>
             <!-- 문제 유형 -->
             <template #item.type="{ item }">
-                <v-chip size="small">{{ item.type }}</v-chip>
+                <span class="type-tag" :class="getTypeClass(item.type)">
+                    {{ item.type }}
+                </span>
             </template>
             <!-- 난이도 -->
             <template #item.difficulty="{ item }">
@@ -218,6 +220,22 @@ const getDifficultyColor = level => {
         case '보통': return 'primary'
         case '어려움': return 'error'
         default: return 'grey'
+    }
+}
+
+const getTypeClass = (type) => {
+    switch (type) {
+        case '선택형':
+        case 'MULTIPLE':
+            return 'type-multiple'
+        case '단답형':
+        case 'SUBJECTIVE':
+            return 'type-subjective'
+        case '서술형':
+        case 'DESCRIPTIVE':
+            return 'type-descriptive'
+        default:
+            return 'type-default'
     }
 }
 
@@ -411,5 +429,38 @@ onMounted(async () => {
 .search-bar {
     margin-bottom: 0;
     margin-left: 16px;
+}
+
+.type-tag {
+    display: inline-flex;
+    align-items: center;
+    padding: 4px 8px;
+    border-radius: 12px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    transition: all 0.2s ease;
+}
+
+.type-multiple {
+    background: #81C784;
+    color: #2E7D32;
+}
+
+.type-subjective {
+    background: #FFB74D;
+    color: #E65100;
+}
+
+.type-descriptive {
+    background: #BA68C8;
+    color: #7B1FA2;
+}
+
+.type-default {
+    background: #90A4AE;
+    color: #37474F;
 }
 </style>

--- a/src/views/employment/JobtestCreatePage.vue
+++ b/src/views/employment/JobtestCreatePage.vue
@@ -1,113 +1,242 @@
 <template>
-    <v-container>
-        <v-row>
-            <v-col cols="12">
-                <h2 class="text-h6 font-weight-bold mb-4">실무 테스트 등록</h2>
-            </v-col>
-        </v-row>
-        <v-text-field v-model="jobtestTitle" label="실무 테스트 이름을 입력해주세요." class="mb-0" variant="outlined" />
+    <v-container class="jobtest-create-page">
+        <!-- 페이지 헤더 -->
+        <div class="page-header">
+            <div class="header-actions">
+                <v-btn prepend-icon="mdi-arrow-left" variant="tonal" @click="goToList" class="list-btn">
+                    목록으로
+                </v-btn>
+            </div>
+            <h2 class="page-title">{{ isEdit ? '실무 테스트 수정' : '실무 테스트 등록' }}</h2>
+            <p class="page-description">실무 테스트 정보를 입력하고 문제를 선택해주세요.</p>
+        </div>
 
-        <v-card class="pa-6 mb-6" elevation="2">
+        <!-- 기본 정보 입력 -->
+        <v-card class="info-card pa-6 mb-6" elevation="2">
+            <div class="card-header">
+                <h3 class="card-title">기본 정보</h3>
+                <v-icon class="card-icon">mdi-information-outline</v-icon>
+            </div>
+            
+            <v-text-field 
+                v-model="jobtestTitle" 
+                label="실무 테스트 이름" 
+                placeholder="실무 테스트 이름을 입력해주세요."
+                class="mb-4" 
+                variant="outlined" 
+                prepend-inner-icon="mdi-format-title"
+            />
+
             <v-row class="align-center" dense>
                 <v-col cols="12" md="3" class="mb-4 mb-md-0">
-                    <div class="form-label">시험 시작 일정</div>
-                    <v-text-field v-model="startedAt" type="datetime-local" variant="outlined" density="comfortable"
-                        hide-details />
+                    <div class="form-label">
+                        <v-icon class="label-icon">mdi-calendar-start</v-icon>
+                        시험 시작 일정
+                    </div>
+                    <v-text-field 
+                        v-model="startedAt" 
+                        type="datetime-local" 
+                        variant="outlined" 
+                        density="comfortable"
+                        hide-details 
+                    />
                 </v-col>
                 <v-col cols="12" md="3" class="mb-4 mb-md-0">
-                    <div class="form-label">시험 종료 일정</div>
-                    <v-text-field v-model="endedAt" type="datetime-local" variant="outlined" density="comfortable"
-                        hide-details />
+                    <div class="form-label">
+                        <v-icon class="label-icon">mdi-calendar-end</v-icon>
+                        시험 종료 일정
+                    </div>
+                    <v-text-field 
+                        v-model="endedAt" 
+                        type="datetime-local" 
+                        variant="outlined" 
+                        density="comfortable"
+                        hide-details 
+                    />
                 </v-col>
                 <v-col cols="12" md="2" class="mb-4 mb-md-0">
-                    <div class="form-label">난이도</div>
-                    <v-select v-model="difficulty" :items="difficultyOptions" item-title="title" item-value="value"
-                        variant="outlined" density="comfortable" hide-details />
+                    <div class="form-label">
+                        <v-icon class="label-icon">mdi-trending-up</v-icon>
+                        난이도
+                    </div>
+                    <v-select 
+                        v-model="difficulty" 
+                        :items="difficultyOptions" 
+                        item-title="title" 
+                        item-value="value"
+                        variant="outlined" 
+                        density="comfortable" 
+                        hide-details 
+                    />
                 </v-col>
                 <v-col cols="12" md="2">
-                    <div class="form-label">시험 시간 (분)</div>
-                    <v-text-field v-model="testTime" type="number" variant="outlined" density="comfortable"
-                        hide-details />
+                    <div class="form-label">
+                        <v-icon class="label-icon">mdi-clock-outline</v-icon>
+                        시험 시간 (분)
+                    </div>
+                    <v-text-field 
+                        v-model="testTime" 
+                        type="number" 
+                        variant="outlined" 
+                        density="comfortable"
+                        hide-details 
+                    />
                 </v-col>
             </v-row>
         </v-card>
-        <div class="table-header-actions">
-            <v-row class="align-center" no-gutters>
-                <v-col cols="12" md="6" class="d-flex align-center">
-                    <h6 class="text-h6 font-weight-bold mb-4 ml-8 mr-4">문제 선택하기</h6>
-                    <Search v-model="search" placeholder="문제 검색" @clear="clearSearch" @search="handleSearch"
-                        class="search-bar" />
-                </v-col>
-                <v-col cols="12" md="6" class="d-flex justify-end">
-                    <v-btn color="primary" variant="tonal" prepend-icon="mdi-plus" @click="dialog = true">
-                        문제 등록하기
-                    </v-btn>
-                </v-col>
-            </v-row>
+
+        <!-- 문제 선택 섹션 -->
+        <v-card class="question-card pa-6 mb-6" elevation="2">
+            <div class="card-header">
+                <h3 class="card-title">문제 선택</h3>
+                <v-icon class="card-icon">mdi-format-list-bulleted</v-icon>
+            </div>
+
+            <div class="table-header-actions">
+                <v-row class="align-center" no-gutters>
+                    <v-col cols="12" md="6" class="d-flex align-center">
+                        <Search 
+                            v-model="search" 
+                            placeholder="문제 검색" 
+                            @clear="clearSearch" 
+                            @search="handleSearch"
+                            class="search-bar" 
+                        />
+                    </v-col>
+                    <v-col cols="12" md="6" class="d-flex justify-end">
+                        <v-btn 
+                            color="primary" 
+                            variant="tonal" 
+                            prepend-icon="mdi-plus" 
+                            @click="dialog = true"
+                            class="add-question-btn"
+                        >
+                            문제 등록하기
+                        </v-btn>
+                    </v-col>
+                </v-row>
+            </div>
+
+            <!-- 문제 리스트 테이블 -->
+            <v-data-table 
+                :headers="questionTableHeaders" 
+                :items="filteredQuestions" 
+                item-key="id" 
+                class="question-table elevation-1 mb-4"
+                :items-per-page="10" 
+                return-object 
+                @click:row="handleQuestionRowClick"
+                hover
+            >
+                <!-- 선택 체크박스 헤더 -->
+                <template #header.select>
+                    <v-checkbox 
+                        :model-value="isAllSelected" 
+                        :indeterminate="isIndeterminate"
+                        @update:model-value="toggleSelectAll" 
+                        hide-details 
+                        density="compact" 
+                    />
+                </template>
+                <!-- 체크박스 컬럼 -->
+                <template #item.select="{ item }">
+                    <v-checkbox 
+                        :model-value="isSelected(item)" 
+                        @update:model-value="() => toggle(item)" 
+                        hide-details
+                        density="compact" 
+                        @click.stop 
+                    />
+                </template>
+                <!-- 문제 유형 -->
+                <template #item.type="{ item }">
+                    <span class="tag-style" :style="getQuestionTypeStyle(item.type)">
+                        {{ getQuestionTypeLabel(item.type) }}
+                    </span>
+                </template>
+                <!-- 난이도 -->
+                <template #item.difficulty="{ item }">
+                    <span class="tag-style" :style="getDifficultyStyle(item.difficulty)">
+                        {{ getDifficultyLabel(item.difficulty) }}
+                    </span>
+                </template>
+                <!-- 점수 입력 -->
+                <template #item.score="{ item }">
+                    <v-text-field 
+                        :model-value="item.score" 
+                        @update:model-value="val => item.score = Number(val)"
+                        type="number" 
+                        variant="underlined" 
+                        density="compact" 
+                        hide-details 
+                        style="width: 80px;"
+                        @click.stop 
+                    />
+                </template>
+                <!-- 문제 내용 -->
+                <template #item.content="{ item }">
+                    <span class="truncate-text">{{ item.content }}</span>
+                </template>
+            </v-data-table>
+
+            <!-- 총점 표시 -->
+            <div class="total-score-section">
+                <div class="total-score-card">
+                    <v-icon class="score-icon">mdi-calculator</v-icon>
+                    <span class="score-label">선택된 문제 총점:</span>
+                    <span class="score-value">{{selectedQuestions.reduce((sum, q) => sum + Number(q.score ?? 0), 0)}}점</span>
+                </div>
+            </div>
+        </v-card>
+
+        <!-- 액션 버튼 -->
+        <div class="action-buttons">
+            <v-btn 
+                variant="tonal" 
+                color="grey" 
+                class="cancel-btn" 
+                @click="cancel"
+                prepend-icon="mdi-close"
+            >
+                취소하기
+            </v-btn>
+            <v-btn 
+                color="primary" 
+                class="submit-btn" 
+                @click="register"
+                prepend-icon="mdi-check"
+            >
+                {{ isEdit ? '수정하기' : '등록하기' }}
+            </v-btn>
         </div>
 
-        <!-- 문제 리스트 v-data-table로 교체 -->
-        <v-data-table :headers="questionTableHeaders" :items="filteredQuestions" item-key="id" class="elevation-1 mb-4"
-            :items-per-page="10" return-object @click:row="handleQuestionRowClick">
-            <!-- 선택 체크박스 헤더 -->
-            <template #header.select>
-                <v-checkbox :model-value="isAllSelected" :indeterminate="isIndeterminate"
-                    @update:model-value="toggleSelectAll" hide-details density="compact" />
-            </template>
-            <!-- 체크박스 컬럼 -->
-            <template #item.select="{ item }">
-                <v-checkbox :model-value="isSelected(item)" @update:model-value="() => toggle(item)" hide-details
-                    density="compact" @click.stop />
-            </template>
-            <!-- 문제 유형 -->
-            <template #item.type="{ item }">
-                <span class="tag-style" :style="getQuestionTypeStyle(item.type)">
-                    {{ getQuestionTypeLabel(item.type) }}
-                </span>
-            </template>
-            <!-- 난이도 -->
-            <template #item.difficulty="{ item }">
-                <span class="tag-style" :style="getDifficultyStyle(item.difficulty)">
-                    {{ getDifficultyLabel(item.difficulty) }}
-                </span>
-            </template>
-            <!-- 점수 입력 -->
-            <template #item.score="{ item }">
-                <v-text-field :model-value="item.score" @update:model-value="val => item.score = Number(val)"
-                    type="number" variant="underlined" density="compact" hide-details style="width: 80px;"
-                    @click.stop />
-            </template>
-            <!-- 문제 내용 -->
-            <template #item.content="{ item }">
-                <span class="truncate-text">{{ item.content }}</span>
-            </template>
-        </v-data-table>
-
-        <div class="text-right mt-2">
-            <span class="text-caption">
-                선택된 문제 총점: {{selectedQuestions.reduce((sum, q) => sum + Number(q.score ?? 0), 0)}}점
-            </span>
-        </div>
-
-        <div class="d-flex justify-end mt-4">
-            <v-btn variant="tonal" color="grey" class="mr-2" @click="cancel">취소하기</v-btn>
-            <v-btn color="primary" @click="register">{{ isEdit ? '수정하기' : '등록하기' }}</v-btn>
-        </div>
-
+        <!-- 모달들 -->
         <v-dialog v-model="dialog" max-width="800">
             <v-card>
                 <QuestionCreateModal @close="dialog = false" @saved="handleNewQuestion" />
             </v-card>
         </v-dialog>
 
-        <SuccessModal v-if="showSuccessModal" message="실무 테스트가 등록되었습니다." @confirm="handleSuccessConfirm"
-            @cancel="showSuccessModal = false" />
+        <SuccessModal 
+            v-if="showSuccessModal" 
+            message="실무 테스트가 등록되었습니다." 
+            @confirm="handleSuccessConfirm"
+            @cancel="showSuccessModal = false" 
+        />
 
-        <Modal v-if="showCancelModal" message="정말 취소하시겠습니까?<br>입력한 내용이 모두 사라집니다." @confirm="handleCancelConfirm"
-            @cancel="handleCancelClose" />
+        <Modal 
+            v-if="showCancelModal" 
+            message="정말 취소하시겠습니까?<br>입력한 내용이 모두 사라집니다." 
+            @confirm="handleCancelConfirm"
+            @cancel="handleCancelClose" 
+        />
 
-        <JobtestQuestionDetailModal v-model="detailDialogVisible" :question="selectedQuestionDetail" :showDelete="false"
-            :showEdit="false" />
+        <JobtestQuestionDetailModal 
+            v-model="detailDialogVisible" 
+            :question="selectedQuestionDetail" 
+            :showDelete="false"
+            :showEdit="false" 
+        />
     </v-container>
 </template>
 
@@ -374,66 +503,365 @@ const handleSearch = (value) => {
     search.value = value
 }
 
+const goToList = () => {
+    router.push({ name: 'JobtestList' });
+}
+
 onMounted(async () => {
     await memberStore.getMyInfo();
 })
 </script>
 
 <style scoped>
-.table-header-actions {
-    display: flex;
-    justify-content: flex-end;
-    align-items: center;
-    margin-top: 50px;
-    margin-bottom: 8px;
-    gap: 8px;
+.jobtest-create-page {
+    padding: 24px;
+    background-color: #f5f7fa;
+    min-height: 100vh;
 }
 
+/* 페이지 헤더 */
+.page-header {
+    margin-bottom: 32px;
+    text-align: center;
+    position: relative;
+}
+
+.header-actions {
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 1;
+}
+
+.list-btn {
+    transition: all 0.2s ease-in-out;
+    border-radius: 8px;
+    font-weight: 500;
+}
+
+.list-btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.page-title {
+    color: #1a237e;
+    font-size: 2rem;
+    font-weight: 700;
+    margin-bottom: 8px;
+    line-height: 1.3;
+}
+
+.page-description {
+    color: #666;
+    font-size: 1rem;
+    margin: 0;
+}
+
+/* 카드 공통 스타일 */
+.info-card,
+.question-card {
+    background: white;
+    border-radius: 16px;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+    transition: all 0.3s ease;
+    border: 1px solid rgba(0, 0, 0, 0.05);
+    overflow: hidden;
+    position: relative;
+}
+
+.info-card::before,
+.question-card::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 4px;
+    background: linear-gradient(90deg, #1976d2, #42a5f5);
+    border-radius: 16px 16px 0 0;
+}
+
+.info-card:hover,
+.question-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+}
+
+/* 카드 헤더 */
+.card-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 24px;
+    padding-bottom: 16px;
+    border-bottom: 1px solid #e0e0e0;
+}
+
+.card-title {
+    color: #1a237e;
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin: 0;
+}
+
+.card-icon {
+    color: #1976d2;
+    font-size: 1.5rem;
+}
+
+/* 폼 라벨 */
 .form-label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
     font-size: 0.95rem;
     font-weight: 500;
-    margin-bottom: 4px;
+    margin-bottom: 8px;
     color: #555;
 }
 
+.label-icon {
+    color: #1976d2;
+    font-size: 1rem;
+}
+
+/* 테이블 헤더 액션 */
+.table-header-actions {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 20px;
+    gap: 16px;
+}
+
+.search-bar {
+    flex: 1;
+    max-width: 400px;
+}
+
+.add-question-btn {
+    transition: all 0.2s ease;
+    border-radius: 8px;
+}
+
+.add-question-btn:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(25, 118, 210, 0.3);
+}
+
+/* 문제 테이블 */
+.question-table {
+    border-radius: 12px;
+    overflow: hidden;
+}
+
+.question-table :deep(.v-data-table__thead) {
+    background-color: #f8f9fa;
+}
+
+.question-table :deep(.v-data-table__thead th) {
+    font-weight: 600;
+    color: #495057;
+    border-bottom: 2px solid #e9ecef;
+    padding: 16px 12px;
+}
+
+.question-table :deep(.v-data-table__td) {
+    padding: 16px 12px;
+    border-bottom: 1px solid #f1f3f4;
+    vertical-align: middle;
+}
+
+.question-table :deep(.v-data-table__tr:hover) {
+    background-color: #f8f9fa !important;
+}
+
+/* 총점 섹션 */
+.total-score-section {
+    margin-top: 20px;
+    display: flex;
+    justify-content: flex-end;
+}
+
+.total-score-card {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: linear-gradient(135deg, #4caf50, #66bb6a);
+    color: white;
+    padding: 12px 20px;
+    border-radius: 20px;
+    font-weight: 600;
+    box-shadow: 0 2px 8px rgba(76, 175, 80, 0.3);
+    transition: all 0.2s ease;
+}
+
+.total-score-card:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(76, 175, 80, 0.4);
+}
+
+.score-icon {
+    font-size: 1.2rem;
+}
+
+.score-label {
+    font-size: 0.9rem;
+}
+
+.score-value {
+    font-size: 1.1rem;
+    font-weight: 700;
+}
+
+/* 액션 버튼 */
+.action-buttons {
+    display: flex;
+    justify-content: center;
+    gap: 16px;
+    margin-top: 32px;
+    padding: 24px;
+    background: white;
+    border-radius: 16px;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.cancel-btn,
+.submit-btn {
+    min-width: 120px;
+    border-radius: 8px;
+    font-weight: 500;
+    transition: all 0.2s ease;
+}
+
+.cancel-btn:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.submit-btn:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(25, 118, 210, 0.3);
+}
+
+/* 태그 스타일 */
+.tag-style {
+    display: inline-flex;
+    align-items: center;
+    padding: 6px 12px;
+    border-radius: 20px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    transition: all 0.2s ease;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.tag-style:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}
+
+/* 텍스트 자르기 */
 .truncate-text {
-    max-width: 500px;
+    max-width: 400px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
     display: inline-block;
     vertical-align: middle;
+    line-height: 1.4;
 }
 
+/* 반응형 디자인 */
 @media (max-width: 960px) {
-    .form-label {
-        margin-bottom: 2px;
+    .jobtest-create-page {
+        padding: 16px;
+    }
+    
+    .page-title {
+        font-size: 1.5rem;
+    }
+    
+    .card-header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 8px;
+    }
+    
+    .table-header-actions {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 12px;
+    }
+    
+    .search-bar {
+        max-width: none;
+    }
+    
+    .add-question-btn {
+        align-self: flex-end;
+    }
+    
+    .action-buttons {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 12px;
+    }
+    
+    .cancel-btn,
+    .submit-btn {
+        min-width: auto;
+    }
+    
+    .truncate-text {
+        max-width: 250px;
     }
 }
 
 @media (max-width: 600px) {
-    .table-header-actions {
-        flex-direction: column;
-        align-items: stretch;
-        gap: 4px;
+    .jobtest-create-page {
+        padding: 12px;
     }
-}
-
-.search-bar {
-    margin-bottom: 0;
-    margin-left: 16px;
-}
-
-.tag-style {
-    display: inline-flex;
-    align-items: center;
-    padding: 4px 8px;
-    border-radius: 12px;
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.3px;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-    transition: all 0.2s ease;
+    
+    .page-title {
+        font-size: 1.3rem;
+    }
+    
+    .page-description {
+        font-size: 0.9rem;
+    }
+    
+    .info-card,
+    .question-card {
+        border-radius: 12px;
+        padding: 20px;
+    }
+    
+    .form-label {
+        font-size: 0.9rem;
+        margin-bottom: 6px;
+    }
+    
+    .card-title {
+        font-size: 1.1rem;
+    }
+    
+    .total-score-card {
+        padding: 10px 16px;
+        font-size: 0.9rem;
+    }
+    
+    .truncate-text {
+        max-width: 200px;
+    }
+    
+    .action-buttons {
+        padding: 16px;
+        border-radius: 12px;
+    }
 }
 </style>

--- a/src/views/employment/JobtestDetailPage.vue
+++ b/src/views/employment/JobtestDetailPage.vue
@@ -263,6 +263,7 @@ const getStatusStyle = (status) => {
 .jobtest-detail-page {
     padding: 24px;
     background-color: #f5f7fa;
+    min-height: 100vh;
 }
 
 .header-actions {
@@ -274,26 +275,45 @@ const getStatusStyle = (status) => {
 
 .list-btn {
     transition: all 0.2s ease-in-out;
+    border-radius: 8px;
+    font-weight: 500;
 }
 
 .list-btn:hover {
     transform: translateY(-2px);
-    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }
 
 .summary-card,
 .detail-card {
     background: white;
-    border-radius: 12px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+    border-radius: 16px;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
     transition: all 0.3s ease;
     margin-bottom: 24px;
+    border: 1px solid rgba(0, 0, 0, 0.05);
+    overflow: hidden;
 }
 
 .summary-card:hover,
 .detail-card:hover {
     transform: translateY(-4px);
-    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.12);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+}
+
+.detail-card {
+    position: relative;
+}
+
+.detail-card::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 4px;
+    background: linear-gradient(90deg, #1976d2, #42a5f5);
+    border-radius: 16px 16px 0 0;
 }
 
 .truncate-text {
@@ -303,10 +323,7 @@ const getStatusStyle = (status) => {
     text-overflow: ellipsis;
     display: inline-block;
     vertical-align: middle;
-}
-
-.v-data-table {
-    cursor: pointer;
+    line-height: 1.4;
 }
 
 .custom-data-table {
@@ -316,26 +333,26 @@ const getStatusStyle = (status) => {
 .custom-data-table tbody tr:hover,
 .custom-data-table .v-data-table__tr:hover,
 .custom-data-table .v-data-table__tr:hover .v-data-table__td {
-    background-color: #f5f5f5 !important;
+    background-color: #f8f9fa !important;
     transition: background-color 0.2s ease;
 }
 
 .custom-data-table .v-data-table__td:hover {
-    background-color: #f5f5f5 !important;
+    background-color: #f8f9fa !important;
 }
 
 /* Vuetify 3의 새로운 클래스명 대응 */
 .custom-data-table .v-data-table__tr:hover .v-data-table__td {
-    background-color: #f5f5f5 !important;
+    background-color: #f8f9fa !important;
 }
 
 /* 더 강력한 선택자 */
 .custom-data-table :deep(.v-data-table__tr:hover) {
-    background-color: #f5f5f5 !important;
+    background-color: #f8f9fa !important;
 }
 
 .custom-data-table :deep(.v-data-table__tr:hover .v-data-table__td) {
-    background-color: #f5f5f5 !important;
+    background-color: #f8f9fa !important;
 }
 
 .question-type-tag,
@@ -343,20 +360,135 @@ const getStatusStyle = (status) => {
 .status-tag {
     display: inline-flex;
     align-items: center;
-    padding: 4px 8px;
-    border-radius: 12px;
+    padding: 6px 12px;
+    border-radius: 20px;
     font-size: 0.75rem;
     font-weight: 600;
     text-transform: uppercase;
-    letter-spacing: 0.3px;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    letter-spacing: 0.5px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
     transition: all 0.2s ease;
+    border: 1px solid rgba(255, 255, 255, 0.2);
 }
 
+.question-type-tag:hover,
+.difficulty-tag:hover,
+.status-tag:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}
+
+/* 테이블 헤더 스타일링 */
+.custom-data-table :deep(.v-data-table__thead) {
+    background-color: #f8f9fa;
+}
+
+.custom-data-table :deep(.v-data-table__thead th) {
+    font-weight: 600;
+    color: #495057;
+    border-bottom: 2px solid #e9ecef;
+    padding: 16px 12px;
+}
+
+/* 테이블 셀 스타일링 */
+.custom-data-table :deep(.v-data-table__td) {
+    padding: 16px 12px;
+    border-bottom: 1px solid #f1f3f4;
+    vertical-align: middle;
+}
+
+/* 링크 스타일링 */
+a.text-decoration-none {
+    color: #1976d2;
+    font-weight: 500;
+    transition: color 0.2s ease;
+}
+
+a.text-decoration-none:hover {
+    color: #1565c0;
+    text-decoration: underline !important;
+}
+
+/* 카드 내부 패딩 조정 */
+.detail-card :deep(.v-card-text) {
+    padding: 20px 24px;
+}
+
+.detail-card :deep(.v-card-title) {
+    padding: 20px 24px 16px;
+    font-weight: 600;
+    color: #1a237e;
+    border-bottom: 1px solid #e0e0e0;
+    background-color: #fafbfc;
+}
+
+/* 페이지네이션 스타일링 */
+.detail-card :deep(.v-data-table-footer) {
+    padding: 16px 24px;
+    border-top: 1px solid #e0e0e0;
+    background-color: #fafbfc;
+}
+
+/* 반응형 디자인 */
 @media (max-width: 960px) {
-    .v-col-md-6 {
-        flex-basis: 100%;
-        max-width: 100%;
+    .jobtest-detail-page {
+        padding: 16px;
+    }
+    
+    .header-actions {
+        flex-direction: column;
+        gap: 16px;
+        align-items: stretch;
+    }
+    
+    .list-btn {
+        align-self: flex-start;
+    }
+    
+    .summary-card,
+    .detail-card {
+        margin-bottom: 16px;
+        border-radius: 12px;
+    }
+    
+    .truncate-text {
+        max-width: 200px;
+    }
+    
+    .custom-data-table :deep(.v-data-table__thead th),
+    .custom-data-table :deep(.v-data-table__td) {
+        padding: 12px 8px;
+    }
+    
+    .question-type-tag,
+    .difficulty-tag,
+    .status-tag {
+        padding: 4px 8px;
+        font-size: 0.7rem;
+    }
+}
+
+@media (max-width: 600px) {
+    .jobtest-detail-page {
+        padding: 12px;
+    }
+    
+    .summary-card,
+    .detail-card {
+        border-radius: 8px;
+    }
+    
+    .truncate-text {
+        max-width: 150px;
+    }
+    
+    .detail-card :deep(.v-card-text) {
+        padding: 16px;
+    }
+    
+    .detail-card :deep(.v-card-title) {
+        padding: 16px;
+        font-size: 1.1rem;
     }
 }
 </style>

--- a/src/views/employment/JobtestDetailPage.vue
+++ b/src/views/employment/JobtestDetailPage.vue
@@ -180,10 +180,26 @@ const goEditJobtest = () => {
     router.push({ name: 'JobtestCreate', query: { jobtestId: jobtest.value.id } });
 }
 
-const goToJobtestAnswers = (applicationJobtestId) => {
-    router.push({
+const goToJobtestAnswers = (applicationJobtestId, applicantData = null) => {
+    const query = {};
+    
+    // 지원자 정보가 있으면 쿼리 파라미터로 전달
+    if (applicantData) {
+        query.applicantName = applicantData.applicantName;
+        query.recruitmentTitle = applicantData.recruitmentTitle;
+        query.applicantId = applicantData.applicantId;
+        query.applicationId = applicantData.applicationId;
+    }
+    
+    // 실무테스트 제목도 함께 전달
+    if (jobtest.value?.title) {
+        query.jobtestTitle = jobtest.value.title;
+    }
+    
+    router.push({ 
         name: 'JobtestAnswerDetail',
-        params: { applicationJobtestId }
+        params: { applicationJobtestId },
+        query
     });
 }
 
@@ -201,12 +217,12 @@ const handleQuestionRowClick = async (event, { item }) => {
 
 // 지원자 행 클릭 핸들러
 const handleApplicantRowClick = (event, { item }) => {
-    goToJobtestAnswers(item.applicationJobtestId);
+    goToJobtestAnswers(item.applicationJobtestId, item);
 }
 
 // 지원자 이름 클릭 핸들러
 const handleApplicantClick = (item) => {
-    goToJobtestAnswers(item.applicationJobtestId);
+    goToJobtestAnswers(item.applicationJobtestId, item);
 }
 
 // 스타일 함수들

--- a/src/views/employment/JobtestDetailPage.vue
+++ b/src/views/employment/JobtestDetailPage.vue
@@ -19,14 +19,91 @@
         <jobtest-summary-card :jobtest="jobtest" class="summary-card" />
 
         <!-- 문제 목록 -->
-        <jobtest-question-list :questions="jobtest.questions" class="detail-card" />
+        <v-card variant="outlined" class="detail-card pa-4">
+            <h3 class="text-subtitle-1 font-weight-bold mb-4">문제 목록</h3>
+            <v-data-table :headers="questionHeaders" :items="validQuestions" :items-per-page="10" item-key="id"
+                class="elevation-1 custom-data-table" hover @click:row="handleQuestionRowClick">
+                <!-- 번호 -->
+                <template #item.index="{ index }">
+                    {{ index + 1 }}
+                </template>
+
+                <!-- 내용 (긴 내용 처리) -->
+                <template #item.content="{ item }">
+                    <span class="truncate-text">{{ item.content }}</span>
+                </template>
+
+                <!-- 유형 -->
+                <template #item.type="{ item }">
+                    <span class="question-type-tag" :style="getQuestionTypeStyle(item.type)">
+                        {{ getQuestionTypeLabel(item.type) }}
+                    </span>
+                </template>
+
+                <!-- 난이도 -->
+                <template #item.difficulty="{ item }">
+                    <span class="difficulty-tag" :style="getDifficultyStyle(item.difficulty)">
+                        {{ getDifficultyLabel(item.difficulty) }}
+                    </span>
+                </template>
+
+                <template #footer="{ page, pageCount, setPage }">
+                    <Pagination :model-value="page" :length="pageCount" :total-visible="5"
+                        @update:modelValue="setPage" />
+                </template>
+            </v-data-table>
+        </v-card>
 
         <!-- 지원자 테이블 -->
-        <jobtest-applicant-table
-            :applications="jobtest.applications"
-            @select="goToJobtestAnswers"
-            class="detail-card"
-        />
+        <v-card variant="outlined" class="detail-card pa-4">
+            <h3 class="text-subtitle-1 font-weight-bold mb-4">지원자 현황</h3>
+            <v-data-table :headers="applicantHeaders" :items="jobtest.applications" :items-per-page="10"
+                item-key="applicationJobtestId" class="elevation-1 custom-data-table" hover
+                @click:row="handleApplicantRowClick">
+                <!-- 번호 -->
+                <template #item.index="{ index }">
+                    {{ index + 1 }}
+                </template>
+
+                <!-- 지원자 (클릭 가능) -->
+                <template #item.applicantName="{ item }">
+                    <a href="#" @click.prevent.stop="handleApplicantClick(item)"
+                        class="text-decoration-none text-blue-darken-1 font-weight-medium">
+                        {{ item.applicantName }}
+                    </a>
+                </template>
+
+                <!-- 채용 공고 (긴 제목 처리) -->
+                <template #item.recruitmentTitle="{ item }">
+                    <span class="truncate-text">{{ item.recruitmentTitle }}</span>
+                </template>
+
+                <!-- 채점 상태 -->
+                <template #item.gradingStatus="{ item }">
+                    <span class="status-tag" :style="getStatusStyle(item.gradingStatus)">
+                        {{ getStatusLabel(item.gradingStatus) }}
+                    </span>
+                </template>
+
+                <!-- 평가 상태 -->
+                <template #item.evaluationStatus="{ item }">
+                    <span class="status-tag" :style="getStatusStyle(item.evaluationStatus)">
+                        {{ getStatusLabel(item.evaluationStatus) }}
+                    </span>
+                </template>
+
+                <template #footer="{ page, pageCount, setPage }">
+                    <Pagination :model-value="page" :length="pageCount" :total-visible="5"
+                        @update:modelValue="setPage" />
+                </template>
+            </v-data-table>
+        </v-card>
+
+        <!-- 문제 상세 보기 모달 -->
+        <QuestionDetailModal v-model="detailDialogVisible" :question="selectedQuestionDetail" :show-delete="false"
+            :show-edit="false" @update:modelValue="(val) => {
+                detailDialogVisible = val;
+            }" />
     </v-container>
 
     <!-- 에러 발생 시 -->
@@ -38,19 +115,27 @@
 </template>
 
 <script setup>
-import { computed, onMounted } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useJobtestDetailStore } from '@/stores/jobtestDetailStore'
+import { useJobtestQuestionStore } from '@/stores/jobtestQuestionStore'
 
 import JobtestSummaryCard from '@/components/employment/JobtestSummaryCard.vue'
-import JobtestQuestionList from '@/components/employment/JobtestQuestionList.vue'
-// import JobtestEvaluationCriteria from '@/components/common/EvaluationCriteriaList.vue'
-import JobtestApplicantTable from '@/components/employment/JobtestApplicantTable.vue'
+import QuestionDetailModal from '@/components/employment/JobtestQuestionDetailModal.vue'
+import Pagination from '@/components/common/Pagination.vue'
+import { getDifficultyLabel, getDifficultyColors } from '@/constants/employment/difficulty.js'
+import { getQuestionTypeLabel, getQuestionTypeColors } from '@/constants/employment/questionTypes.js'
+import { getStatusLabel } from '@/constants/employment/jobtestStatus.js'
 
 const router = useRouter()
 const props = defineProps(['jobtestId'])
 
 const jobtestDetailStore = useJobtestDetailStore()
+const jobtestQuestionStore = useJobtestQuestionStore()
+
+// 모달 관련 상태
+const detailDialogVisible = ref(false)
+const selectedQuestionDetail = ref(null)
 
 onMounted(() => {
     jobtestDetailStore.fetchJobtestDetail(Number(props.jobtestId))
@@ -59,6 +144,33 @@ onMounted(() => {
 const jobtest = computed(() => jobtestDetailStore.jobtest)
 const loading = computed(() => jobtestDetailStore.loading)
 const error = computed(() => jobtestDetailStore.error)
+
+// 문제 목록 테이블 헤더
+const questionHeaders = [
+    { title: '번호', key: 'index', sortable: false, width: '80px' },
+    { title: '내용', key: 'content', align: 'start' },
+    { title: '배점', key: 'score', align: 'center', width: '100px' },
+    { title: '유형', key: 'type', align: 'center', width: '120px' },
+    { title: '난이도', key: 'difficulty', align: 'center', width: '120px' }
+]
+
+// 지원자 테이블 헤더
+const applicantHeaders = [
+    { title: 'No', key: 'index', sortable: false, width: '60px' },
+    { title: '지원자', key: 'applicantName', align: 'start' },
+    { title: '채용 공고', key: 'recruitmentTitle', align: 'start' },
+    { title: '채점 상태', key: 'gradingStatus', align: 'center', width: '120px' },
+    { title: '채점 점수', key: 'gradingScore', align: 'center', width: '100px' },
+    { title: '채점자', key: 'gradingMemberName', align: 'start', width: '120px' },
+    { title: '평가 상태', key: 'evaluationStatus', align: 'center', width: '120px' },
+    { title: '평가 점수', key: 'evaluationScore', align: 'center', width: '100px' },
+    { title: '평가자', key: 'evaluationMemberName', align: 'start', width: '120px' }
+]
+
+// 유효한 문제들만 필터링
+const validQuestions = computed(() => {
+    return (jobtest.value?.questions || []).filter(q => q);
+})
 
 const goJobtestList = () => {
     router.push({ name: 'JobtestList' });
@@ -69,11 +181,66 @@ const goEditJobtest = () => {
 }
 
 const goToJobtestAnswers = (applicationJobtestId) => {
-    router.push({ 
+    router.push({
         name: 'JobtestAnswerDetail',
         params: { applicationJobtestId }
     });
 }
+
+// 문제 행 클릭 핸들러
+const handleQuestionRowClick = async (event, { item }) => {
+    try {
+        console.log('item', item)
+        await jobtestQuestionStore.loadQuestion(item.questionId)
+        selectedQuestionDetail.value = { ...jobtestQuestionStore.form }
+        detailDialogVisible.value = true
+    } catch (err) {
+        console.error('문제 상세 정보를 불러오는 중 오류가 발생했습니다:', err)
+    }
+}
+
+// 지원자 행 클릭 핸들러
+const handleApplicantRowClick = (event, { item }) => {
+    goToJobtestAnswers(item.applicationJobtestId);
+}
+
+// 지원자 이름 클릭 핸들러
+const handleApplicantClick = (item) => {
+    goToJobtestAnswers(item.applicationJobtestId);
+}
+
+// 스타일 함수들
+const getQuestionTypeStyle = (type) => {
+    const colors = getQuestionTypeColors(type);
+    return {
+        backgroundColor: colors.background,
+        color: colors.text,
+    };
+};
+
+const getDifficultyStyle = (difficulty) => {
+    const colors = getDifficultyColors(difficulty);
+    return {
+        backgroundColor: colors.background,
+        color: colors.text,
+    };
+};
+
+const getStatusStyle = (status) => {
+    // 상태에 따른 색상 매핑
+    const statusColors = {
+        'PENDING': { background: '#fff3cd', text: '#856404' },
+        'IN_PROGRESS': { background: '#cce5ff', text: '#004085' },
+        'COMPLETED': { background: '#d4edda', text: '#155724' },
+        'FAILED': { background: '#f8d7da', text: '#721c24' }
+    };
+
+    const colors = statusColors[status] || { background: '#f8f9fa', text: '#6c757d' };
+    return {
+        backgroundColor: colors.background,
+        color: colors.text,
+    };
+};
 </script>
 
 <style scoped>
@@ -95,7 +262,7 @@ const goToJobtestAnswers = (applicationJobtestId) => {
 
 .list-btn:hover {
     transform: translateY(-2px);
-    box-shadow: 0 4px 10px rgba(0,0,0,0.1);
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
 }
 
 .summary-card,
@@ -111,6 +278,63 @@ const goToJobtestAnswers = (applicationJobtestId) => {
 .detail-card:hover {
     transform: translateY(-4px);
     box-shadow: 0 8px 20px rgba(0, 0, 0, 0.12);
+}
+
+.truncate-text {
+    max-width: 300px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: inline-block;
+    vertical-align: middle;
+}
+
+.v-data-table {
+    cursor: pointer;
+}
+
+.custom-data-table {
+    cursor: pointer;
+}
+
+.custom-data-table tbody tr:hover,
+.custom-data-table .v-data-table__tr:hover,
+.custom-data-table .v-data-table__tr:hover .v-data-table__td {
+    background-color: #f5f5f5 !important;
+    transition: background-color 0.2s ease;
+}
+
+.custom-data-table .v-data-table__td:hover {
+    background-color: #f5f5f5 !important;
+}
+
+/* Vuetify 3의 새로운 클래스명 대응 */
+.custom-data-table .v-data-table__tr:hover .v-data-table__td {
+    background-color: #f5f5f5 !important;
+}
+
+/* 더 강력한 선택자 */
+.custom-data-table :deep(.v-data-table__tr:hover) {
+    background-color: #f5f5f5 !important;
+}
+
+.custom-data-table :deep(.v-data-table__tr:hover .v-data-table__td) {
+    background-color: #f5f5f5 !important;
+}
+
+.question-type-tag,
+.difficulty-tag,
+.status-tag {
+    display: inline-flex;
+    align-items: center;
+    padding: 4px 8px;
+    border-radius: 12px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    transition: all 0.2s ease;
 }
 
 @media (max-width: 960px) {

--- a/src/views/employment/JobtestDetailPage.vue
+++ b/src/views/employment/JobtestDetailPage.vue
@@ -10,9 +10,9 @@
             <v-btn prepend-icon="mdi-arrow-left" variant="tonal" @click="goJobtestList">
                 목록으로
             </v-btn>
-            <v-btn color="primary" variant="tonal" prepend-icon="mdi-pencil" @click="goEditJobtest">
+            <!-- <v-btn color="primary" variant="tonal" prepend-icon="mdi-pencil" @click="goEditJobtest">
                 수정하기
-            </v-btn>
+            </v-btn> -->
         </div>
 
         <!-- 요약 카드 -->

--- a/src/views/employment/JobtestDetailPage.vue
+++ b/src/views/employment/JobtestDetailPage.vue
@@ -5,9 +5,9 @@
     </v-container>
 
     <!-- 로딩 완료 후 jobtest가 있을 때 -->
-    <v-container v-else-if="jobtest" fluid>
-        <div class="d-flex justify-space-between align-center mb-4">
-            <v-btn prepend-icon="mdi-arrow-left" variant="tonal" @click="goJobtestList">
+    <v-container v-else-if="jobtest" class="jobtest-detail-page">
+        <div class="header-actions">
+            <v-btn prepend-icon="mdi-arrow-left" variant="tonal" @click="goJobtestList" class="list-btn">
                 목록으로
             </v-btn>
             <!-- <v-btn color="primary" variant="tonal" prepend-icon="mdi-pencil" @click="goEditJobtest">
@@ -16,27 +16,22 @@
         </div>
 
         <!-- 요약 카드 -->
-        <jobtest-summary-card :jobtest="jobtest" class="mb-6" />
+        <jobtest-summary-card :jobtest="jobtest" class="summary-card" />
 
-        <v-row>
-            <v-col cols="6">
-                <jobtest-question-list :questions="jobtest.questions" />
-            </v-col>
-            <!-- <v-col cols="6">
-        <jobtest-evaluation-criteria :criteria="jobtest.evaluationCriteria" />
-      </v-col> -->
-        </v-row>
+        <!-- 문제 목록 -->
+        <jobtest-question-list :questions="jobtest.questions" class="detail-card" />
 
         <!-- 지원자 테이블 -->
         <jobtest-applicant-table
             :applications="jobtest.applications"
             @select="goToJobtestAnswers"
+            class="detail-card"
         />
     </v-container>
 
     <!-- 에러 발생 시 -->
     <v-container v-else class="text-center py-10">
-        <v-alert type="error" title="오류 발생">
+        <v-alert type="error" title="오류 발생" prominent>
             실무 테스트 정보를 불러오는 중 문제가 발생했습니다.
         </v-alert>
     </v-container>
@@ -80,3 +75,48 @@ const goToJobtestAnswers = (applicationJobtestId) => {
     });
 }
 </script>
+
+<style scoped>
+.jobtest-detail-page {
+    padding: 24px;
+    background-color: #f5f7fa;
+}
+
+.header-actions {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 24px;
+}
+
+.list-btn {
+    transition: all 0.2s ease-in-out;
+}
+
+.list-btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 10px rgba(0,0,0,0.1);
+}
+
+.summary-card,
+.detail-card {
+    background: white;
+    border-radius: 12px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+    transition: all 0.3s ease;
+    margin-bottom: 24px;
+}
+
+.summary-card:hover,
+.detail-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.12);
+}
+
+@media (max-width: 960px) {
+    .v-col-md-6 {
+        flex-basis: 100%;
+        max-width: 100%;
+    }
+}
+</style>

--- a/src/views/employment/JobtestEnterPage.vue
+++ b/src/views/employment/JobtestEnterPage.vue
@@ -1,4 +1,6 @@
 <template>
+    <CareerHeader />
+    
     <v-container v-if="loading" class="d-flex justify-center align-center" style="height: 300px;">
         <v-progress-circular indeterminate color="primary" size="60" />
     </v-container>
@@ -66,6 +68,7 @@ import { useRouter } from 'vue-router'
 import { useJobtestDetailStore } from '@/stores/jobtestDetailStore'
 import { useJobtestExamStore } from '@/stores/jobtestExamStore';
 import AlertModal from '@/components/common/AlertModal.vue'
+import CareerHeader from '@/components/career/CareerHeader.vue'
 
 const router = useRouter()
 

--- a/src/views/employment/JobtestExamPage.vue
+++ b/src/views/employment/JobtestExamPage.vue
@@ -1,16 +1,29 @@
 <template>
   <div class="exam-layout">
-    <div class="exam-sidebar-wrap">
-      <ExamSidebar :testInfo="testInfo" :currentIndex="currentIndex" :totalQuestions="questions.length"
-        :timeLeft="timeLeft" @moveTo="handleMoveTo" @submit="openSubmitModal" />
-    </div>
-    <div class="exam-question-area">
-      <QuestionView :question="questions[currentIndex]" :answer="answers[currentIndex] ?? ''"
-        :questionIndex="currentIndex" @updateAnswer="updateAnswer" />
-      <div class="nav-buttons">
-        <button @click="async () => await prev()" :disabled="currentIndex === 0">이전</button>
-        <button v-if="currentIndex < questions.length - 1" @click="next">다음</button>
-        <button v-else class="submit-btn" @click="openSubmitModal">제출하기</button>
+    <CareerHeader />
+    <div class="exam-content-wrapper">
+      <div class="exam-sidebar-wrap">
+        <ExamSidebar
+          :testInfo="testInfo"
+          :currentIndex="currentIndex"
+          :totalQuestions="questions.length"
+          :timeLeft="timeLeft"
+          @moveTo="handleMoveTo"
+          @submit="openSubmitModal"
+        />
+      </div>
+      <div class="exam-question-area">
+        <QuestionView
+          :question="questions[currentIndex]"
+          :answer="answers[currentIndex] ?? ''"
+          :questionIndex="currentIndex"
+          @updateAnswer="updateAnswer"
+        />
+        <div class="nav-buttons">
+          <button @click="async () => await prev()" :disabled="currentIndex === 0">이전</button>
+          <button v-if="currentIndex < questions.length - 1" @click="next">다음</button>
+          <button v-else class="submit-btn" @click="openSubmitModal">제출하기</button>
+        </div>
       </div>
     </div>
     <Modal v-if="showSubmitModal" message="제출하시겠습니까?" @confirm="handleSubmitConfirm" @cancel="closeSubmitModal" />
@@ -26,6 +39,7 @@ import QuestionView from '@/components/employment/QuestionView.vue'
 import { QUESTION_TYPES } from '@/constants/employment/questionTypes'
 import AnswerRequestDTO from '@/dto/employment/jobtest/answerRequestDTO'
 import Modal from '@/components/common/Modal.vue'
+import CareerHeader from '@/components/career/CareerHeader.vue'
 
 const store = useJobtestExamStore()
 const route = useRoute()
@@ -152,11 +166,14 @@ async function handleSubmitConfirm() {
 <style scoped>
 .exam-layout {
   display: flex;
-  flex-direction: row;
-  align-items: flex-start;
+  flex-direction: column;
   min-height: 100vh;
   background: #20432b;
-  /* 좌측 배경색, 필요시 조정 */
+}
+
+.exam-content-wrapper {
+  display: flex;
+  flex: 1;
 }
 
 .exam-sidebar-wrap {
@@ -164,7 +181,6 @@ async function handleSubmitConfirm() {
   display: flex;
   justify-content: center;
   align-items: flex-start;
-  min-height: 100vh;
   background: transparent;
   padding-top: 60px;
 }
@@ -175,13 +191,11 @@ async function handleSubmitConfirm() {
   flex-direction: column;
   align-items: flex-start;
   justify-content: flex-start;
-  min-height: 100vh;
   background: #fff;
   border-radius: 24px;
-  margin: 40px 0 40px 0;
+  margin: 40px 24px;
   padding: 48px 56px 56px 56px;
-  box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.10);
-  margin-left: 24px;
+  box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.1);
   max-width: 900px;
   width: 100%;
 }

--- a/src/views/employment/JobtestListPage.vue
+++ b/src/views/employment/JobtestListPage.vue
@@ -49,6 +49,13 @@
                         </a>
                     </template>
 
+                    <!-- 난이도 -->
+                    <template #item.difficulty="{ item }">
+                        <span class="difficulty-tag" :style="getDifficultyStyle(item.difficulty)">
+                            {{ getDifficultyLabel(item.difficulty) }}
+                        </span>
+                    </template>
+
                     <template #footer="{ page, pageCount, setPage }">
                         <Pagination :model-value="page" :length="pageCount" :total-visible="5" @update:modelValue="setPage" />
                     </template>
@@ -72,6 +79,7 @@ import { useRouter } from 'vue-router';
 import { useToast } from 'vue-toastification';
 import { useJobtestListStore } from '@/stores/jobtestListStore';
 import Pagination from '@/components/common/Pagination.vue'
+import { getDifficultyLabel, getDifficultyColors } from '@/constants/employment/difficulty.js'
 
 const router = useRouter();
 const store = useJobtestListStore();
@@ -153,6 +161,14 @@ const toggleSelectAll = (selectAll) => {
         selectedJobtests.value = [];
     }
 }
+
+const getDifficultyStyle = (difficulty) => {
+    const colors = getDifficultyColors(difficulty);
+    return {
+        backgroundColor: colors.background,
+        color: colors.text,
+    };
+};
 </script>
 
 <style scoped>
@@ -167,5 +183,18 @@ const toggleSelectAll = (selectAll) => {
 
 .v-data-table {
     cursor: pointer;
+}
+
+.difficulty-tag {
+    display: inline-flex;
+    align-items: center;
+    padding: 4px 8px;
+    border-radius: 12px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    transition: all 0.2s ease;
 }
 </style>

--- a/src/views/employment/JobtestQuestionFormPage.vue
+++ b/src/views/employment/JobtestQuestionFormPage.vue
@@ -1,27 +1,84 @@
 <template>
-    <v-container>
-        <h2 class="text-h6 font-weight-bold mb-4">{{ isEdit ? '문제 수정' : '문제 등록' }}</h2>
+    <v-container class="question-form-page">
+        <!-- 페이지 헤더 -->
+        <div class="page-header">
+            <div class="header-actions">
+                <v-btn prepend-icon="mdi-arrow-left" variant="tonal" @click="goBack" class="back-btn">
+                    목록으로
+                </v-btn>
+            </div>
+            <h2 class="page-title">{{ isEdit ? '문제 수정' : '문제 등록' }}</h2>
+            <p class="page-description">문제 유형을 선택하고 내용을 입력해주세요.</p>
+        </div>
 
-        <v-tabs v-model="activeTab" :disabled="isEdit">
-            <v-tab value="MULTIPLE">선택형</v-tab>
-            <v-tab value="SUBJECTIVE">단답형</v-tab>
-            <!-- <v-tab value="DESCRIPTIVE">서술형</v-tab> -->
-        </v-tabs>
+        <!-- 메인 폼 카드 -->
+        <v-card class="form-card pa-6 mb-6" elevation="2">
+            <div class="card-header">
+                <h3 class="card-title">문제 정보</h3>
+                <v-icon class="card-icon">mdi-help-circle-outline</v-icon>
+            </div>
 
-        <!-- 난이도 -->
-        <v-select v-model="form.difficulty" :items="difficultyOptions" label="난이도" item-title="label" item-value="value"
-            variant="outlined" class="mt-4 mb-4" />
+            <!-- 문제 유형 탭 -->
+            <div class="tab-section">
+                <v-tabs v-model="activeTab" :disabled="isEdit" class="question-tabs">
+                    <v-tab value="MULTIPLE" class="tab-item">
+                        <v-icon class="tab-icon">mdi-format-list-bulleted</v-icon>
+                        선택형
+                    </v-tab>
+                    <v-tab value="SUBJECTIVE" class="tab-item">
+                        <v-icon class="tab-icon">mdi-text-box-outline</v-icon>
+                        단답형
+                    </v-tab>
+                    <!-- <v-tab value="DESCRIPTIVE">서술형</v-tab> -->
+                </v-tabs>
+            </div>
 
-        <!-- 문제 유형별 입력 폼 -->
-        <component :is="currentComponent" v-model:form="form" />
+            <!-- 난이도 선택 -->
+            <div class="difficulty-section">
+                <div class="form-label">
+                    <v-icon class="label-icon">mdi-trending-up</v-icon>
+                    난이도
+                </div>
+                <v-select 
+                    v-model="form.difficulty" 
+                    :items="difficultyOptions" 
+                    label="난이도를 선택해주세요" 
+                    item-title="label" 
+                    item-value="value"
+                    variant="outlined" 
+                    class="difficulty-select"
+                    prepend-inner-icon="mdi-trending-up"
+                />
+            </div>
 
-        <div class="d-flex justify-end mt-4">
-            <v-btn variant="tonal" @click="goBack">취소</v-btn>
-            <v-btn color="primary" class="ml-2" @click="handleSubmit">
+            <!-- 문제 유형별 입력 폼 -->
+            <div class="component-section">
+                <component :is="currentComponent" v-model:form="form" />
+            </div>
+        </v-card>
+
+        <!-- 액션 버튼 -->
+        <div class="action-buttons">
+            <v-btn 
+                variant="tonal" 
+                color="grey" 
+                class="cancel-btn" 
+                @click="goBack"
+                prepend-icon="mdi-close"
+            >
+                취소
+            </v-btn>
+            <v-btn 
+                color="primary" 
+                class="submit-btn" 
+                @click="handleSubmit"
+                prepend-icon="mdi-check"
+            >
                 {{ isEdit ? '수정하기' : '등록하기' }}
             </v-btn>
         </div>
 
+        <!-- 모달들 -->
         <SuccessModal 
             v-if="showSuccessModal" 
             :message="isEdit ? '문제 수정이 완료되었습니다.' : '문제 등록이 완료되었습니다.'"
@@ -160,3 +217,270 @@ onMounted(async () => {
     }
 })
 </script>
+
+<style scoped>
+.question-form-page {
+    padding: 24px;
+    background-color: #f5f7fa;
+    min-height: 100vh;
+}
+
+/* 페이지 헤더 */
+.page-header {
+    margin-bottom: 32px;
+    text-align: center;
+    position: relative;
+}
+
+.header-actions {
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 1;
+}
+
+.back-btn {
+    transition: all 0.2s ease-in-out;
+    border-radius: 8px;
+    font-weight: 500;
+}
+
+.back-btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.page-title {
+    color: #1a237e;
+    font-size: 2rem;
+    font-weight: 700;
+    margin-bottom: 8px;
+    line-height: 1.3;
+}
+
+.page-description {
+    color: #666;
+    font-size: 1rem;
+    margin: 0;
+}
+
+/* 폼 카드 */
+.form-card {
+    background: white;
+    border-radius: 16px;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+    transition: all 0.3s ease;
+    border: 1px solid rgba(0, 0, 0, 0.05);
+    overflow: hidden;
+    position: relative;
+}
+
+.form-card::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 4px;
+    background: linear-gradient(90deg, #1976d2, #42a5f5);
+    border-radius: 16px 16px 0 0;
+}
+
+.form-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+}
+
+/* 카드 헤더 */
+.card-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 24px;
+    padding-bottom: 16px;
+    border-bottom: 1px solid #e0e0e0;
+}
+
+.card-title {
+    color: #1a237e;
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin: 0;
+}
+
+.card-icon {
+    color: #1976d2;
+    font-size: 1.5rem;
+}
+
+/* 탭 섹션 */
+.tab-section {
+    margin-bottom: 24px;
+}
+
+.question-tabs {
+    border-radius: 12px;
+    overflow: hidden;
+}
+
+.question-tabs :deep(.v-tab) {
+    font-weight: 500;
+    text-transform: none;
+    letter-spacing: normal;
+    min-height: 48px;
+    transition: all 0.2s ease;
+}
+
+.question-tabs :deep(.v-tab:hover) {
+    background-color: rgba(25, 118, 210, 0.04);
+}
+
+.question-tabs :deep(.v-tab--selected) {
+    background-color: rgba(25, 118, 210, 0.08);
+    color: #1976d2;
+    font-weight: 600;
+}
+
+.tab-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.tab-icon {
+    font-size: 1.1rem;
+}
+
+/* 난이도 섹션 */
+.difficulty-section {
+    margin-bottom: 24px;
+}
+
+.form-label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.95rem;
+    font-weight: 500;
+    margin-bottom: 8px;
+    color: #555;
+}
+
+.label-icon {
+    color: #1976d2;
+    font-size: 1rem;
+}
+
+.difficulty-select {
+    max-width: 300px;
+}
+
+/* 컴포넌트 섹션 */
+.component-section {
+    margin-top: 24px;
+}
+
+/* 액션 버튼 */
+.action-buttons {
+    display: flex;
+    justify-content: center;
+    gap: 16px;
+    margin-top: 32px;
+    padding: 24px;
+    background: white;
+    border-radius: 16px;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.cancel-btn,
+.submit-btn {
+    min-width: 120px;
+    border-radius: 8px;
+    font-weight: 500;
+    transition: all 0.2s ease;
+}
+
+.cancel-btn:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.submit-btn:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(25, 118, 210, 0.3);
+}
+
+/* 반응형 디자인 */
+@media (max-width: 960px) {
+    .question-form-page {
+        padding: 16px;
+    }
+    
+    .page-title {
+        font-size: 1.5rem;
+    }
+    
+    .card-header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 8px;
+    }
+    
+    .action-buttons {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 12px;
+    }
+    
+    .cancel-btn,
+    .submit-btn {
+        min-width: auto;
+    }
+    
+    .difficulty-select {
+        max-width: none;
+    }
+}
+
+@media (max-width: 600px) {
+    .question-form-page {
+        padding: 12px;
+    }
+    
+    .page-title {
+        font-size: 1.3rem;
+    }
+    
+    .page-description {
+        font-size: 0.9rem;
+    }
+    
+    .form-card {
+        border-radius: 12px;
+        padding: 20px;
+    }
+    
+    .form-label {
+        font-size: 0.9rem;
+        margin-bottom: 6px;
+    }
+    
+    .card-title {
+        font-size: 1.1rem;
+    }
+    
+    .action-buttons {
+        padding: 16px;
+        border-radius: 12px;
+    }
+    
+    .question-tabs :deep(.v-tab) {
+        min-height: 40px;
+        font-size: 0.9rem;
+    }
+    
+    .tab-icon {
+        font-size: 1rem;
+    }
+}
+</style>

--- a/src/views/employment/JobtestQuestionListPage.vue
+++ b/src/views/employment/JobtestQuestionListPage.vue
@@ -56,15 +56,15 @@
 
                     <!-- 유형 -->
                     <template #item.type="{ item }">
-                        <span class="type-tag" :class="getTypeClass(item.type)">
-                            {{ item.type }}
+                        <span class="type-tag" :style="getQuestionTypeStyle(item.type)">
+                            {{ getQuestionTypeLabel(item.type) }}
                         </span>
                     </template>
 
                     <!-- 난이도 -->
                     <template #item.difficulty="{ item }">
-                        <span class="difficulty-tag" :class="getDifficultyClass(item.difficulty)">
-                            {{ item.difficulty }}
+                        <span class="difficulty-tag" :style="getDifficultyStyle(item.difficulty)">
+                            {{ getDifficultyLabel(item.difficulty) }}
                         </span>
                     </template>
 
@@ -104,6 +104,8 @@ import QuestionDetailModal from '@/components/employment/JobtestQuestionDetailMo
 import { useJobtestQuestionStore } from '@/stores/jobtestQuestionStore'
 import Pagination from '@/components/common/Pagination.vue'
 import Modal from '@/components/common/Modal.vue'
+import { getDifficultyLabel, getDifficultyColors } from '@/constants/employment/difficulty.js'
+import { getQuestionTypeLabel, getQuestionTypeColors } from '@/constants/employment/questionTypes.js'
 
 const router = useRouter()
 const toast = useToast()
@@ -211,37 +213,21 @@ const toggleSelectAll = () => {
     }
 }
 
-const getTypeClass = (type) => {
-    switch (type) {
-        case '선택형':
-        case 'MULTIPLE':
-            return 'type-multiple'
-        case '단답형':
-        case 'SUBJECTIVE':
-            return 'type-subjective'
-        case '서술형':
-        case 'DESCRIPTIVE':
-            return 'type-descriptive'
-        default:
-            return 'type-default'
-    }
-}
+const getQuestionTypeStyle = (type) => {
+    const colors = getQuestionTypeColors(type);
+    return {
+        backgroundColor: colors.background,
+        color: colors.text,
+    };
+};
 
-const getDifficultyClass = (difficulty) => {
-    switch (difficulty) {
-        case '쉬움':
-        case 'EASY':
-            return 'difficulty-easy'
-        case '보통':
-        case 'MEDIUM':
-            return 'difficulty-medium'
-        case '어려움':
-        case 'HARD':
-            return 'difficulty-hard'
-        default:
-            return 'difficulty-medium'
-    }
-}
+const getDifficultyStyle = (difficulty) => {
+    const colors = getDifficultyColors(difficulty);
+    return {
+        backgroundColor: colors.background,
+        color: colors.text,
+    };
+};
 </script>
 
 <style scoped>
@@ -259,39 +245,7 @@ const getDifficultyClass = (difficulty) => {
     /* 수직 정렬을 위해 추가 */
 }
 
-.type-tag {
-    display: inline-flex;
-    align-items: center;
-    padding: 4px 8px;
-    border-radius: 12px;
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.3px;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-    transition: all 0.2s ease;
-}
-
-.type-multiple {
-    background: #81C784;
-    color: #2E7D32;
-}
-
-.type-subjective {
-    background: #FFB74D;
-    color: #E65100;
-}
-
-.type-descriptive {
-    background: #BA68C8;
-    color: #7B1FA2;
-}
-
-.type-default {
-    background: #90A4AE;
-    color: #37474F;
-}
-
+.type-tag,
 .difficulty-tag {
     display: inline-flex;
     align-items: center;
@@ -303,21 +257,5 @@ const getDifficultyClass = (difficulty) => {
     letter-spacing: 0.3px;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
     transition: all 0.2s ease;
-    color: white;
-}
-
-.difficulty-easy {
-    background: #A5D6A7;
-    color: #2E7D32;
-}
-
-.difficulty-medium {
-    background: #90CAF9;
-    color: #1565C0;
-}
-
-.difficulty-hard {
-    background: #EF9A9A;
-    color: #C62828;
 }
 </style>

--- a/src/views/employment/JobtestQuestionListPage.vue
+++ b/src/views/employment/JobtestQuestionListPage.vue
@@ -54,6 +54,20 @@
                         </a>
                     </template>
 
+                    <!-- 유형 -->
+                    <template #item.type="{ item }">
+                        <span class="type-tag" :class="getTypeClass(item.type)">
+                            {{ item.type }}
+                        </span>
+                    </template>
+
+                    <!-- 난이도 -->
+                    <template #item.difficulty="{ item }">
+                        <span class="difficulty-tag" :class="getDifficultyClass(item.difficulty)">
+                            {{ item.difficulty }}
+                        </span>
+                    </template>
+
                     <template #footer="{ page, pageCount, setPage }">
                         <Pagination :model-value="page" :length="pageCount" :total-visible="5" @update:modelValue="setPage" />
                     </template>
@@ -196,6 +210,38 @@ const toggleSelectAll = () => {
         selectedQuestions.value = [...questionStore.questions];
     }
 }
+
+const getTypeClass = (type) => {
+    switch (type) {
+        case '선택형':
+        case 'MULTIPLE':
+            return 'type-multiple'
+        case '단답형':
+        case 'SUBJECTIVE':
+            return 'type-subjective'
+        case '서술형':
+        case 'DESCRIPTIVE':
+            return 'type-descriptive'
+        default:
+            return 'type-default'
+    }
+}
+
+const getDifficultyClass = (difficulty) => {
+    switch (difficulty) {
+        case '쉬움':
+        case 'EASY':
+            return 'difficulty-easy'
+        case '보통':
+        case 'MEDIUM':
+            return 'difficulty-medium'
+        case '어려움':
+        case 'HARD':
+            return 'difficulty-hard'
+        default:
+            return 'difficulty-medium'
+    }
+}
 </script>
 
 <style scoped>
@@ -211,5 +257,67 @@ const toggleSelectAll = () => {
     display: inline-block;
     vertical-align: top;
     /* 수직 정렬을 위해 추가 */
+}
+
+.type-tag {
+    display: inline-flex;
+    align-items: center;
+    padding: 4px 8px;
+    border-radius: 12px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    transition: all 0.2s ease;
+}
+
+.type-multiple {
+    background: #81C784;
+    color: #2E7D32;
+}
+
+.type-subjective {
+    background: #FFB74D;
+    color: #E65100;
+}
+
+.type-descriptive {
+    background: #BA68C8;
+    color: #7B1FA2;
+}
+
+.type-default {
+    background: #90A4AE;
+    color: #37474F;
+}
+
+.difficulty-tag {
+    display: inline-flex;
+    align-items: center;
+    padding: 4px 8px;
+    border-radius: 12px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    transition: all 0.2s ease;
+    color: white;
+}
+
+.difficulty-easy {
+    background: #A5D6A7;
+    color: #2E7D32;
+}
+
+.difficulty-medium {
+    background: #90CAF9;
+    color: #1565C0;
+}
+
+.difficulty-hard {
+    background: #EF9A9A;
+    color: #C62828;
 }
 </style>

--- a/src/views/errors/ForbiddenPage.vue
+++ b/src/views/errors/ForbiddenPage.vue
@@ -1,0 +1,22 @@
+<template>
+    <v-container class="d-flex flex-column align-center justify-center text-center" fill-height>
+        <v-icon size="100" color="error" class="mb-6">mdi-shield-off</v-icon>
+
+        <h1 class="text-h4 font-weight-bold mb-2">접근이 거부되었습니다</h1>
+        <p class="text-subtitle-1 mb-6">이 페이지에 접근할 권한이 없습니다.<br> 관리자에게 문의하거나 홈으로 돌아가세요.</p>
+
+        <v-btn color="primary" @click="goHome" class="px-6 py-3" size="large">
+            홈으로 가기
+        </v-btn>
+    </v-container>
+</template>
+
+<script setup>
+import { useRouter } from 'vue-router';
+
+const router = useRouter();
+
+const goHome = () => {
+    router.push('/');
+};
+</script>

--- a/src/views/errors/NotFoundPage.vue
+++ b/src/views/errors/NotFoundPage.vue
@@ -1,0 +1,22 @@
+<template>
+    <v-container class="d-flex flex-column align-center justify-center text-center" fill-height>
+        <v-icon size="100" color="warning" class="mb-6">mdi-alert-circle-outline</v-icon>
+
+        <h1 class="text-h4 font-weight-bold mb-2">페이지를 찾을 수 없습니다</h1>
+        <p class="text-subtitle-1 mb-6">요청하신 페이지가 존재하지 않거나 삭제되었습니다.</p>
+
+        <v-btn color="primary" @click="goHome" class="px-6 py-3" size="large">
+            홈으로 가기
+        </v-btn>
+    </v-container>
+</template>
+
+<script setup>
+import { useRouter } from 'vue-router';
+
+const router = useRouter();
+
+const goHome = () => {
+    router.push('/');
+};
+</script>


### PR DESCRIPTION
### 🪄 PR 타입

- [X] 신규 기능
- [X] 기능 수정
- [ ] 리팩토링
- [X] 버그 픽스

### #️⃣ 연관된 이슈

close #이슈번호

### 📝 변경 사항
- 실무테스트 단답형 답안 등록 안되던 버그 수정
- 문제 등록 모달에 서술형 탭 삭제
- 지원자, 실무테스트 정보 답안에 나오게 연동
- 실무테스트 입장/응시 페이지 헤더 수정
- 실무테스트 관련 페이지 css 수정
- 에러페이지 추가
- 지원서에 실무테스트 할당 구현
- 결재 작성 시 상위 카테고리는 안나오게 수정

### 💭 참고 사항
- 지원서에 실무테스트 할당 실패 시 에러 토스트가 이상하게 나옵니다. 수정이 필요할 것 같습니다.
- 실무테스트 할당할 때 실무테스트 정보 중 시간이 안나오고 있어서 수정할 예정입니다.
- 지원지 목록에서 실무테스트 할당한 지원자를 가시적으로 표현해야 합니다..

### 📷 관련 스크린샷
- 실무테스트 조회
![{EF7E29DE-FD46-4F9D-92B3-D77638D1C600}](https://github.com/user-attachments/assets/5e10752a-8d18-4bb3-8638-1d58977ec0c6)

- 실무테스트 등록
![{E94D9D4B-0487-4DF0-90E2-4156DF4C30DD}](https://github.com/user-attachments/assets/08cf45be-68bc-41a3-b44c-f908518384a2)

- 실무테스트 문제 조회
![{3D649DD2-62AC-4807-B12B-EA11FAE7AF90}](https://github.com/user-attachments/assets/fd885598-392d-4445-9859-40a4a371bbd4)

- 실무테스트 문제 등록
![{120008CA-1C7D-4508-89DE-1CF20333B372}](https://github.com/user-attachments/assets/0b4b84ba-2054-4c1a-92e3-6f3c677312fb)

- 실무테스트 페이지
![{A1460E18-6B91-4CD0-851A-D917320F3A3F}](https://github.com/user-attachments/assets/f955a395-9d99-4f84-a86b-d11cbd19a3ac)


- 실무테스트 응시 페이지
![{54C5F98D-87AC-45F9-B6D1-5236B606E88F}](https://github.com/user-attachments/assets/e3640847-5766-446f-846f-44edf3370175)


### 🧪 테스트 계획 또는 완료 사항
실무테스트 쪽이 전체적으로 다 수정되었습니다. 
- [ ] [실무테스트 페이지](http://localhost:8080/employment/jobtests)
- [ ] [실무테스트 문제 페이지](http://localhost:8080/employment/jobtest-questions)
- [ ] [실무테스트 입장 페이지](http://localhost:8080/employment/jobtest/exam/2000/enter)
- [ ] [실무테스트 응시 페이지](http://localhost:8080/employment/jobtest/exam/take/2000)