### PR TITLE
[feat] 시험 시간 연동 + 실제로 움직이게

### DIFF
--- a/src/views/employment/JobtestExamPage.vue
+++ b/src/views/employment/JobtestExamPage.vue
@@ -98,6 +98,19 @@ watch(answers, (val) => {
 
 const showSubmitModal = ref(false)
 
+// 자동 제출 중복 방지 플래그
+const isAutoSubmitting = ref(false)
+
+// timeLeft가 0이 되면 자동 제출 및 이동
+watch(timeLeft, async (val) => {
+  if (val === 0 && !isAutoSubmitting.value) {
+    isAutoSubmitting.value = true
+    await saveCurrentAnswer()
+    await store.submitAnswers(examData.value.applicationJobTestId)
+    router.push({ name: 'JobtestEnter', params: { jobtestId: examData.value.jobtestId } })
+  }
+})
+
 function updateAnswer(val) {
   console.log('🔄 updateAnswer 호출:', {
     currentIndex: currentIndex.value,

--- a/src/views/employment/JobtestExamPage.vue
+++ b/src/views/employment/JobtestExamPage.vue
@@ -4,7 +4,7 @@
     <div class="exam-content-wrapper">
       <div class="exam-sidebar-wrap">
         <ExamSidebar
-          :testInfo="testInfo"
+          :testInfo="testInfo.testTime"
           :currentIndex="currentIndex"
           :totalQuestions="questions.length"
           :timeLeft="timeLeft"
@@ -31,7 +31,7 @@
 </template>
 
 <script setup>
-import { ref, computed, watch, onMounted } from 'vue'
+import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useJobtestExamStore } from '@/stores/jobtestExamStore'
 import ExamSidebar from '@/components/employment/ExamSidebar.vue'
@@ -49,6 +49,8 @@ const examData = computed(() => store.examData)
 const questions = computed(() => examData.value?.questions ?? [])
 const testInfo = computed(() => ({
   title: examData.value?.title ?? '',
+  testTime: examData.value?.testTime ?? 0,
+  startedAt: examData.value.startedAt,
 }))
 
 const currentIndex = ref(0)
@@ -56,7 +58,22 @@ const answers = ref([])
 
 const getStorageKey = () => `jobtest-answers-${examData.value?.applicationJobTestId}`
 
+const timeLeft = ref(0)
+
+// startedAt 기준으로 남은 시간(초)을 계산해서 timeLeft에 반영
+function updateTimeLeft() {
+  if (!testInfo.value.startedAt) return
+  const startedAt = new Date(testInfo.value.startedAt).getTime()
+  const now = Date.now()
+  const total = testInfo.value.testTime * 60 // 전체 시험 시간(초)
+  const elapsed = Math.floor((now - startedAt) / 1000)
+  timeLeft.value = Math.max(total - elapsed, 0)
+}
+
+let timer = null
 onMounted(() => {
+  console.log('🧪 testInfo:', testInfo.value)
+  // 답안 복원
   const saved = localStorage.getItem(getStorageKey())
   if (saved) {
     try {
@@ -66,13 +83,18 @@ onMounted(() => {
       }
     } catch (e) { /* ignore */ }
   }
+  // 남은 시간 실시간 갱신 시작
+  updateTimeLeft()
+  timer = setInterval(updateTimeLeft, 1000)
+})
+
+onUnmounted(() => {
+  if (timer) clearInterval(timer)
 })
 
 watch(answers, (val) => {
   localStorage.setItem(getStorageKey(), JSON.stringify(val))
 }, { deep: true })
-
-const timeLeft = ref(40 * 60) // 40분 (예시)
 
 const showSubmitModal = ref(false)
 
@@ -117,7 +139,7 @@ async function saveCurrentAnswer(idx = currentIndex.value) {
   const dto = new AnswerRequestDTO({
     content,
     applicationJobTestId: examData.value.applicationJobTestId,
-    questionId: question.questionId
+    questionId: question.questionId,
   })
   
   console.log('📤 저장할 답안 DTO:', dto.toJSON())


### PR DESCRIPTION
### 🪄 PR 타입

- [X] 신규 기능
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] 버그 픽스

### #️⃣ 연관된 이슈

close #이슈번호

### 📝 변경 사항
- 시험 시간 연동 및 움직이게 설정
- 응시 시간 끝나면 쫓겨나게 설정

---
### 💬 리뷰 요구사항 (선택)
- DB에서 현재 시간과 시험 시간을 적절하게 설정해야 동작합니다.
- 입장 페이지부터 시작해야 시험 시간이 올바르게 설정됩니다.
- 백엔드의 https://github.com/Pive-Guyz/be14-fin-Empick-BE/pull/340 PR과 함께 확인해주세요

### 📷 관련 스크린샷
- 실무테스트 응시 페이지
![{395DBE1A-4856-45E1-B66B-A1F14BA06706}](https://github.com/user-attachments/assets/790061c6-bb9a-4090-8f3b-6fd290c642eb)
- 응시 시간이 끝난 경우 DB에 자동 저장
![{320B213B-6B00-4933-AC9F-49B9CBF21457}](https://github.com/user-attachments/assets/6373ae86-a1cd-47d4-9987-9827eea7d16f)


### 🧪 테스트 계획 또는 완료 사항

- [ ] [시험 입장 페이지](http://localhost:8080/employment/jobtest/exam/1/enter)
