### PR TITLE
[refactor] 결재 페이지 모달,토스트 통일 / fullMenu 수정

### DIFF
--- a/src/components/common/MainSidebar.vue
+++ b/src/components/common/MainSidebar.vue
@@ -75,7 +75,7 @@ const userRoles = computed(() => authStore.userInfo?.roles || [])
 
 // 현재 경로에 따라 헤더 메뉴 결정
 const headerTitle = computed(() => {
-    if (route.path.startsWith('/hr')) return '인사'
+    if (route.path.startsWith('/orgstructure')) return '인사'
     if (route.path.startsWith('/attendance')) return '근태'
     if (route.path.startsWith('/approval')) return '결재'
     if (route.path.startsWith('/employment')) return '채용'

--- a/src/constants/common/fullMenu.js
+++ b/src/constants/common/fullMenu.js
@@ -23,22 +23,21 @@ export const fullMenu = {
         }
     ],
     인사: [
-        {
-            label: '조직 관리',
-            roles: [RoleCode.HR_ACCESS],
-            children: [
-                { label: '부서 관리', path: '/orgstructure/dept-manage' },
-                { label: '직무 관리', path: '/orgstructure/job-manage' },
-                { label: '직급 관리', path: '/orgstructure/rank-manage' },
-                { label: '직책 관리', path: '/orgstructure/position-manage' }
-            ]
-        },
+        // {
+        //     label: '조직 관리',
+        //     roles: [RoleCode.HR_ACCESS],
+        //     children: [
+        //         { label: '부서 관리', path: '/orgstructure/dept-manage' },
+        //         { label: '직무 관리', path: '/orgstructure/job-manage' },
+        //         { label: '직급 관리', path: '/orgstructure/rank-manage' },
+        //         { label: '직책 관리', path: '/orgstructure/position-manage' }
+        //     ]
+        // },
         {
             label: '사원 관리',
             roles: [RoleCode.HR_ACCESS],
             children: [
                 { label: "신규 사원 등록", path: "/orgstructure/member-register" },
-                { label: "사원 목록", path: "/attendance/all" },
                 { label: "사원정보변경 요청", path: "/orgstructure/members/edit-request" }
             ]
         }


### PR DESCRIPTION
### 🪄 PR 타입
- [ ] 신규 기능
- [ ] 기능 수정
- [x] 리팩토링
- [ ] 버그 픽스

### 📝 변경 사항
* 결재 페이지 모달,토스트 통일 
* 인사관리 사원목록 제거 및 조직관리 주석처리
* 인사 탭 선택 시 사이드바 변경되도록 수정

### 📷 관련 스크린샷
* 결재
![image](https://github.com/user-attachments/assets/dc51faaf-e9ba-4f35-9867-6a482256cc53)
![image](https://github.com/user-attachments/assets/e0aa73f7-6c46-4d3c-a762-e53cd693bc49)
![image](https://github.com/user-attachments/assets/5e298f63-bde6-441d-a37f-25f7f86bca22)
![image](https://github.com/user-attachments/assets/f1fe297e-af01-4cdd-bfac-4066cf50bd3e)

* 인사
![image](https://github.com/user-attachments/assets/0e6cfd4d-9786-4061-8839-2cbfef324c50)

### 🧪 테스트 계획 또는 완료 사항
- [결재 상세 조회 페이지](http://localhost:8080/approval/inbox/1)
- [신규 사원 등록 페이지](http://localhost:8080/orgstructure/member-register)
