### PR TITLE
[fix] 지원서/지원자 페이지에서 실무테스트 토스트 오류 수정

### DIFF
--- a/src/views/approval/ApprovalCreatePage.vue
+++ b/src/views/approval/ApprovalCreatePage.vue
@@ -106,7 +106,13 @@
 
                     <!-- 제출 버튼 -->
                     <div class="d-flex justify-end mt-6">
-                        <v-btn color="success" class="approval-btn" @click="handleSubmit">등록</v-btn>
+                        <v-btn 
+                            :class="['approval-btn', { 'approval-btn--disabled': !isFormValid }]" 
+                            @click="handleSubmit" 
+                            :disabled="!isFormValid"
+                        >
+                            등록
+                        </v-btn>
                     </div>
                 </div>
             </v-col>
@@ -160,6 +166,21 @@ const jobOptions = computed(() =>
 const filteredCategoryList = computed(() =>
     categoryList.value.filter(category => category.approvalCategoryId === null)
 );
+
+// 폼 유효성 검사
+const isFormValid = computed(() => {
+    // 결재 유형이 선택되어 있는지 확인
+    if (!form.value.categoryId) {
+        return false;
+    }
+    
+    // 모든 결재 항목이 입력되어 있는지 확인
+    if (!form.value.contents || form.value.contents.length === 0) {
+        return false;
+    }
+    
+    return form.value.contents.every(c => c.content !== null && c.content !== '');
+});
 
 onMounted(async () => {
     approvalStore.resetForm();
@@ -307,6 +328,14 @@ onBeforeUnmount(() => {
     border: 1.5px solid #7BAE6C !important;
     color: #fff !important;
     background: #7BAE6C !important;
+}
+
+.approval-btn--disabled {
+    background: #B8D4B0 !important;
+    border-color: #B8D4B0 !important;
+    color: #fff !important;
+    opacity: 0.7;
+    cursor: not-allowed;
 }
 
 .approval-guide {

--- a/src/views/employment/ApplicantPage.vue
+++ b/src/views/employment/ApplicantPage.vue
@@ -577,6 +577,7 @@ const handleJobtestSelected = async (jobtest) => {
     await applicantStore.fetchApplicantFullInfoList()
   } catch (error) {
     console.error('실무테스트 할당 실패:', error)
+    toast.error('해당 지원서에 이미 실무테스트가 할당되어 있습니다.');
   }
 }
 

--- a/src/views/employment/ApplicationPage.vue
+++ b/src/views/employment/ApplicationPage.vue
@@ -1661,7 +1661,7 @@ function handleJobtestButtonClick() {
     goToJobtestAnswerDetail()
   } else {
     // 실무테스트 미응시인 경우 토스트 메시지 표시
-    toast.info('실무테스트가 아직 수행되지 않았습니다.')
+    // toast.info('실무테스트가 아직 수행되지 않았습니다.')
   }
 }
 


### PR DESCRIPTION
### 🪄 PR 타입

- [ ] 신규 기능
- [ ] 기능 수정
- [ ] 리팩토링
- [X] 버그 픽스

### #️⃣ 연관된 이슈

close #이슈번호

### 📝 변경 사항
- 지원서 페이지 실무테스트 미응시 토스트 두번뜨는 오류 수정
- 지원자 페이지 실무테스트 재할당 시 토스트 안뜨던 오류 수정

---
### 📷 관련 스크린샷
![{CF925E13-F8DB-4D97-8877-6F9166013287}](https://github.com/user-attachments/assets/573f49b8-6a1c-4bf0-a53e-ed084a458cd3)
![{21637D0D-1310-48F2-BECC-EB912F33912D}](https://github.com/user-attachments/assets/691b9545-29db-4d3e-8aa4-48d52d828f1c)


### 🧪 테스트 계획 또는 완료 사항

- [ ] [지원자 목록](http://localhost:8080/employment/applicant)
- [ ] [지원서](http://localhost:8080/employment/applications/3?applicantId=3&applicationId=3&name=%EB%B0%95%EC%A4%80%EC%98%81&phone=010-3456-7890&email=joonyoung.park@example.com&profileUrl=https://picsum.photos/seed/app3/200&birth=1990-02-11&address=%EC%84%9C%EC%9A%B8%EC%8B%9C+%EC%86%A1%ED%8C%8C%EA%B5%AC+%EC%98%AC%EB%A6%BC%ED%94%BD%EB%A1%9C+789&recruitmentId=1&introduceRatingResultId&jobId&jobName&createdAt=2025-06-26T20:22:17&status=PASSED_PRACTICAL&updatedAt&updatedBy&from=/employment/applicant)
